### PR TITLE
Fixed Drawer Overlay Behavior to Prevent Content Shifting

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,5 +1,5 @@
-import React, {useState} from "react";
-import {Link, Outlet, useLocation} from "react-router-dom";
+import React, { useState } from "react";
+import { Link, Outlet, useLocation } from "react-router-dom";
 import {
     AppBar,
     Box,
@@ -11,24 +11,23 @@ import {
     ListItemText,
     Toolbar,
     Typography,
+    Backdrop,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
-import CloudIcon from '@mui/icons-material/Cloud';
-import HomeIcon from '@mui/icons-material/Home';
-import AssignmentIcon from '@mui/icons-material/Assignment';
-import WorkspacesIcon from '@mui/icons-material/Workspaces';
+import CloudIcon from "@mui/icons-material/Cloud";
+import HomeIcon from "@mui/icons-material/Home";
+import AssignmentIcon from "@mui/icons-material/Assignment";
+import WorkspacesIcon from "@mui/icons-material/Workspaces";
 
-// use relative path to load Logo
-import volcanoLogo from '../assets/volcano-icon-color.svg';
+// Logo import
+import volcanoLogo from "../assets/volcano-icon-color.svg";
 
 const Layout = () => {
-    // Hooks must be used inside component functions
     const location = useLocation();
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(false); // Set default to false for overlay effect
 
-    // constants can be kept outside the component
-    const volcanoOrange = "#E34C26"; // orange red theme
-    const headerGrey = "#424242"; // dark gray top stripe
+    const volcanoOrange = "#E34C26";
+    const headerGrey = "#424242";
     const drawerWidth = 240;
 
     const handleDrawerToggle = () => {
@@ -36,14 +35,15 @@ const Layout = () => {
     };
 
     const menuItems = [
-        {text: "Dashboard", icon: <HomeIcon/>, path: "/dashboard"},
-        {text: "Jobs", icon: <AssignmentIcon/>, path: "/jobs"},
-        {text: "Queues", icon: <CloudIcon/>, path: "/queues"},
-        {text: "Pods", icon: <WorkspacesIcon/>, path: "/pods"},
+        { text: "Dashboard", icon: <HomeIcon />, path: "/dashboard" },
+        { text: "Jobs", icon: <AssignmentIcon />, path: "/jobs" },
+        { text: "Queues", icon: <CloudIcon />, path: "/queues" },
+        { text: "Pods", icon: <WorkspacesIcon />, path: "/pods" },
     ];
 
     return (
-        <Box sx={{display: "flex"}}>
+        <Box sx={{ display: "flex" }}>
+            {/* Top Navigation Bar */}
             <AppBar
                 position="fixed"
                 sx={{
@@ -57,42 +57,42 @@ const Layout = () => {
                         aria-label="toggle drawer"
                         onClick={handleDrawerToggle}
                         edge="start"
-                        sx={{mr: 2, color: "white"}}
+                        sx={{ mr: 2, color: "white" }}
                     >
-                        <MenuIcon/>
+                        <MenuIcon />
                     </IconButton>
                     <Typography
                         variant="h6"
                         noWrap
                         component="div"
-                        sx={{
-                            color: "#ffffff",
-                            fontWeight: 500,
-                        }}
+                        sx={{ color: "#ffffff", fontWeight: 500 }}
                     >
                         Volcano Dashboard
                     </Typography>
                 </Toolbar>
             </AppBar>
 
+            {/* Drawer (Overlay Style) */}
             <Drawer
-                variant="permanent"
+                variant="temporary"
+                open={open}
+                onClose={handleDrawerToggle}
+                ModalProps={{
+                    keepMounted: true, // Improves performance on mobile
+                }}
                 sx={{
-                    width: open ? drawerWidth : 60,
-                    flexShrink: 0,
-                    [`& .MuiDrawer-paper`]: {
-                        width: open ? drawerWidth : 60,
+                    "& .MuiDrawer-paper": {
+                        width: drawerWidth,
                         boxSizing: "border-box",
                         backgroundColor: "#f5f5f5",
-                        transition: "width 0.2s",
-                        overflowX: "hidden",
-                        display: "flex",
-                        flexDirection: "column",
+                        position: "fixed",
+                        height: "100vh",
+                        transition: "width 0.2s ease-in-out",
                     },
                 }}
             >
-                <Toolbar/>
-                <Box sx={{overflow: "auto", flexGrow: 1}}>
+                <Toolbar />
+                <Box sx={{ overflow: "auto", flexGrow: 1 }}>
                     <List>
                         {menuItems.map((item) => (
                             <ListItem
@@ -115,12 +115,13 @@ const Layout = () => {
                                 }}
                             >
                                 <ListItemIcon>{item.icon}</ListItemIcon>
-                                {open && <ListItemText primary={item.text}/>}
+                                <ListItemText primary={item.text} />
                             </ListItem>
                         ))}
                     </List>
                 </Box>
-                {/* Logo and text part */}
+
+                {/* Logo Section */}
                 <Box
                     sx={{
                         p: 1,
@@ -130,40 +131,43 @@ const Layout = () => {
                         alignItems: "center",
                         mt: "auto",
                         mb: 1,
-                        // borderTop: "1px solid rgba(0, 0, 0, 0.12)",
                     }}
                 >
-                    <img
-                        src={volcanoLogo}
-                        alt="Volcano Logo"
-                        style={{
-                            maxWidth: open ? "115%" : "60px",
-                            height: "auto",
-                            transition: "max-width 0.2s",
-                            marginBottom: "1px",
-                        }}
-                    />
-                    {/* {open && (
-            <Typography
-              sx={{
-                fontWeight: 700,
-                color: "#000",
-                fontSize: "1.4rem",
-                letterSpacing: "0.1em",
-                mt: -6,
-              }}
-            >
-              VOLCANO
-            </Typography>
-          )} */}
+<img
+    src={volcanoLogo}
+    alt="Volcano Logo"
+    style={{
+        maxWidth: "115%",
+        height: "auto",
+        marginBottom: "1px",
+        '@media (min-width: 600px)': {
+            display: "block",
+        },
+    }}
+/>
                 </Box>
             </Drawer>
+
+            {/* Backdrop (Dim screen when drawer is open) */}
+            {open && (
+                <Backdrop
+                    open={open}
+                    onClick={handleDrawerToggle}
+                    sx={{ zIndex: (theme) => theme.zIndex.drawer - 1, backgroundColor: "rgba(0,0,0,0.4)" }}
+                />
+            )}
+
+            {/* Main Content */}
             <Box
                 component="main"
-                sx={{flexGrow: 1, p: 3, backgroundColor: "white"}}
+                sx={{
+                    flexGrow: 1,
+                    p: 3,
+                    backgroundColor: "white",
+                }}
             >
-                <Toolbar/>
-                <Outlet/>
+                <Toolbar />
+                <Outlet />
             </Box>
         </Box>
     );

--- a/frontend/src/components/Queues.jsx
+++ b/frontend/src/components/Queues.jsx
@@ -371,7 +371,7 @@ const Queues = () => {
                         </TableRow>
                     </TableHead>
                     <TableBody>
-                        {sortedQueues
+                    {sortedQueues
                             .map((queue) => (
                                 <TableRow
                                     hover
@@ -407,7 +407,7 @@ const Queues = () => {
                                     </TableCell>
                                 </TableRow>
                             ))}
-                    < /TableBody>
+                        </TableBody>
                 </Table>
             </TableContainer>
             <Box


### PR DESCRIPTION
Fixes #21 
**Description**:
This pull request addresses the issue where opening the drawer causes the main content to shift rightward. Instead, the drawer will now overlay the content, maintaining a stable layout and improving the user experience.

**Changes Made:**

- Added a Backdrop component to improve visibility when the drawer is open.
- Enabled clicking outside the drawer to close it automatically.


### **Before**:
![Screenshot from 2025-02-10 20-06-00](https://github.com/user-attachments/assets/e1fa117c-f1b9-459d-ad22-954acee15e0b)

### **After**:
 ![image](https://github.com/user-attachments/assets/efb8a15b-366f-4541-9520-49feb491fbb5)


**Impact:**
This update improves UI stability and enhances the user experience across all screen sizes
