### PR TITLE
Optimized sidebar to make it responsive

### DIFF
--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -24,7 +24,15 @@ import volcanoLogo from '../assets/volcano-icon-color.svg';
 const Layout = () => {
     // Hooks must be used inside component functions
     const location = useLocation();
-    const [open, setOpen] = useState(true);
+    const [open, setOpen] = useState(window.innerWidth >= 768);
+
+    useEffect(() => {
+        const handleResize = () => {
+            setOpen(window.innerWidth >= 768);
+        };
+        window.addEventListener("resize", handleResize);
+        return () => window.removeEventListener("resize", handleResize);
+    }, []);
 
     // constants can be kept outside the component
     const volcanoOrange = "#E34C26"; // orange red theme


### PR DESCRIPTION
Solves #30 
On large screens (>= 768px), the drawer starts open and permanent.
On small screens (< 768px), the drawer starts closed and temporary (slides in/out).
Manually clicking the menu button still works.

This will now fully adapt to different screen sizes and work perfectly on mobile devices too.