### PR TITLE
[Security] Add security context configuration

### DIFF
--- a/deployment/build/frontend/Dockerfile
+++ b/deployment/build/frontend/Dockerfile
@@ -16,6 +16,6 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 
 COPY frontend/nginx.conf /etc/nginx/nginx.conf
 
-EXPOSE 80
+EXPOSE 8080
 
 CMD ["nginx", "-g", "daemon off;"]

--- a/deployment/volcano-dashboard.yaml
+++ b/deployment/volcano-dashboard.yaml
@@ -16,15 +16,32 @@ spec:
       labels:
         app: volcano-dashboard
     spec:
+      securityContext:
+        seLinuxOptions:
+          level: s0:c123,c456
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: volcano-dashboard
       containers:
         - image: volcanosh/vc-dashboard-frontend:latest
           imagePullPolicy: Always
           name: frontend
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: frontend
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+          volumeMounts:
+            - mountPath: /var/cache/nginx
+              name: nginx-cache
+            - mountPath: /run
+              name: nginx-run
         - image: volcanosh/vc-dashboard-backend:latest
           imagePullPolicy: Always
           name: backend
@@ -32,6 +49,18 @@ spec:
             - containerPort: 3001
               name: backend
               protocol: TCP
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
 ---
 
 # volcano dashboard serviceAccount
@@ -115,6 +144,6 @@ spec:
     - name: frontend
       port: 80
       protocol: TCP
-      targetPort: 80
+      targetPort: 8080
   selector:
     app: volcano-dashboard

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -3,7 +3,7 @@ events {}
 http {
     include  mime.types;
     server {
-        listen 80;
+        listen 8080;
         server_name localhost;
 
         location / {


### PR DESCRIPTION
Related issue: https://github.com/volcano-sh/volcano/issues/4170, for security audit, deployment of the dashboard has to add some security context configuration, such as:
- Configure runAsNonRoot and runAsUser
- Add seccompProfile
- Configure seLinuxOptions, for reference see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#assign-selinux-labels-to-a-container
- Default drop all capabilities, add capabilities as needed
- Configure allowPrivilegeEscalation to false

Besides, because runAsUser is set to 1000, the frontend container cannot bind to port 80, otherwise a bind error will be reported, so it is changed to bind to port 8080