### PR TITLE
upgrade ui of the table

### DIFF
--- a/frontend/src/components/common/EmptyState.jsx
+++ b/frontend/src/components/common/EmptyState.jsx
@@ -1,0 +1,143 @@
+import React from "react";
+import { Box, Typography, Button, useTheme, alpha } from "@mui/material";
+
+const EmptyState = ({
+    resourceType = "Resource",
+    hasFilters = false,
+    onClearFilters = () => {},
+    onRefresh = () => {},
+    customMessages = {},
+    customButtons = {},
+}) => {
+    const theme = useTheme();
+
+    const defaultMessages = {
+        noDataTitle: `No ${resourceType}s Available`,
+        noDataDescription: `There are currently no ${resourceType.toLowerCase()}s deployed in the cluster.`,
+        noMatchTitle: `No Matching ${resourceType}s Found`,
+        noMatchDescription: `No ${resourceType.toLowerCase()}s match your current filter criteria. Try adjusting your filters to see more results.`,
+    };
+
+    const messages = { ...defaultMessages, ...customMessages };
+
+    const defaultButtons = {
+        clearFiltersText: "Clear Filters",
+        refreshText: "Refresh",
+    };
+
+    const buttonTexts = { ...defaultButtons, ...customButtons };
+
+    return (
+        <Box
+            sx={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                padding: 6,
+                minHeight: "300px",
+                textAlign: "center",
+            }}
+        >
+            <Box
+                sx={{
+                    mb: 3,
+                    height: "120px",
+                    width: "120px",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    opacity: 0.8,
+                }}
+            >
+                <svg
+                    width="120"
+                    height="120"
+                    viewBox="0 0 120 120"
+                    xmlns="http://www.w3.org/2000/svg"
+                >
+                    <path
+                        d="M60 10L105 35V85L60 110L15 85V35L60 10Z"
+                        fill={theme.palette.primary.main}
+                    />
+                    <path
+                        d="M60 40L80 50V70L60 80L40 70V50L60 40Z"
+                        fill={theme.palette.background.paper}
+                    />
+                    <path
+                        d="M60 40V60L80 50M60 60V80M60 60L40 50"
+                        stroke={alpha(theme.palette.primary.main, 0.3)}
+                        strokeWidth="1"
+                    />
+                    <text
+                        x="60"
+                        y="95"
+                        fontSize="14"
+                        fontWeight="500"
+                        fill={theme.palette.primary.contrastText}
+                        textAnchor="middle"
+                        style={{ textTransform: "lowercase" }}
+                    >
+                        {resourceType.toLowerCase()}
+                    </text>
+                </svg>
+            </Box>
+
+            <Typography variant="h5" sx={{ mb: 1, fontWeight: "medium" }}>
+                {hasFilters ? messages.noMatchTitle : messages.noDataTitle}
+            </Typography>
+
+            <Typography
+                variant="body1"
+                color="text.secondary"
+                sx={{ maxWidth: "400px", mb: 3 }}
+            >
+                {hasFilters
+                    ? messages.noMatchDescription
+                    : messages.noDataDescription}
+            </Typography>
+
+            {hasFilters ? (
+                <Button
+                    variant="outlined"
+                    onClick={onClearFilters}
+                    sx={{ mr: 2 }}
+                >
+                    {buttonTexts.clearFiltersText}
+                </Button>
+            ) : (
+                <Button
+                    variant="contained"
+                    onClick={onRefresh}
+                    startIcon={
+                        <svg
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            xmlns="http://www.w3.org/2000/svg"
+                        >
+                            <path
+                                d="M20 12c0-4.42-3.58-8-8-8s-8 3.58-8 8 3.58 8 8 8c2.75 0 5.17-1.39 6.61-3.5"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                            />
+                            <path
+                                d="M20 5v7h-7"
+                                stroke="currentColor"
+                                strokeWidth="2"
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                            />
+                        </svg>
+                    }
+                >
+                    {buttonTexts.refreshText}
+                </Button>
+            )}
+        </Box>
+    );
+};
+
+export default EmptyState;

--- a/frontend/src/components/jobs/JobTable/JobTable.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTable.jsx
@@ -9,9 +9,10 @@ import {
 } from "@mui/material";
 import JobTableHeader from "./JobTableHeader";
 import JobTableRow from "./JobTableRow";
+import EmptyState from "../../common/EmptyState";
 
 const JobTable = ({
-    jobs,
+    jobs = [],
     handleJobClick,
     filters,
     uniqueStatuses,
@@ -22,8 +23,24 @@ const JobTable = ({
     handleFilterClose,
     sortDirection,
     toggleSortDirection,
+    onRefresh,
 }) => {
     const theme = useTheme();
+
+    // Check if filters are applied
+    const hasFilters =
+        filters.status !== "All" ||
+        filters.namespace !== "All" ||
+        (filters.queue && filters.queue !== "All");
+
+    // Function to clear all filters
+    const handleClearFilters = () => {
+        handleFilterClose("status", "All");
+        handleFilterClose("namespace", "All");
+        if (filters.queue) {
+            handleFilterClose("queue", "All");
+        }
+    };
 
     return (
         <TableContainer
@@ -66,13 +83,35 @@ const JobTable = ({
                     toggleSortDirection={toggleSortDirection}
                 />
                 <TableBody>
-                    {jobs.map((job) => (
-                        <JobTableRow
-                            key={`${job.metadata.namespace}-${job.metadata.name}`}
-                            job={job}
-                            handleJobClick={handleJobClick}
-                        />
-                    ))}
+                    {jobs.length > 0 ? (
+                        jobs.map((job) => (
+                            <JobTableRow
+                                key={`${job.metadata.namespace}-${job.metadata.name}`}
+                                job={job}
+                                handleJobClick={handleJobClick}
+                            />
+                        ))
+                    ) : (
+                        <tr>
+                            <td colSpan="100%">
+                                <EmptyState
+                                    resourceType="Job"
+                                    hasFilters={hasFilters}
+                                    onClearFilters={handleClearFilters}
+                                    onRefresh={onRefresh}
+                                    customMessages={{
+                                        noDataDescription:
+                                            "There are currently no jobs scheduled in the cluster.",
+                                        noMatchDescription:
+                                            "No jobs match your current filter criteria. Try adjusting your filters to see more results.",
+                                    }}
+                                    customButtons={{
+                                        refreshText: "Refresh Jobs",
+                                    }}
+                                />
+                            </td>
+                        </tr>
+                    )}
                 </TableBody>
             </Table>
         </TableContainer>

--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -218,6 +218,7 @@ const Jobs = () => {
                 handleFilterClose={handleFilterClose}
                 sortDirection={sortDirection}
                 toggleSortDirection={toggleSortDirection}
+                onRefresh={handleRefresh}
             />
             <JobPagination
                 pagination={pagination}

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -167,6 +167,7 @@ const Pods = () => {
                 onSortDirectionToggle={toggleSortDirection}
                 onFilterChange={handleFilterChange}
                 onPodClick={handlePodClick}
+                onRefresh={handleRefresh}
             />
             <PodsPagination
                 totalPods={totalPods}

--- a/frontend/src/components/pods/PodsTable/PodsTable.jsx
+++ b/frontend/src/components/pods/PodsTable/PodsTable.jsx
@@ -9,6 +9,7 @@ import {
 } from "@mui/material";
 import TableHeader from "./TableHeader";
 import PodRow from "./PodRow";
+import EmptyState from "../../common/EmptyState";
 
 const PodsTable = ({
     pods,
@@ -18,6 +19,7 @@ const PodsTable = ({
     onSortDirectionToggle,
     onFilterChange,
     onPodClick,
+    onRefresh,
 }) => {
     const theme = useTheme();
     const [anchorEl, setAnchorEl] = React.useState({
@@ -81,6 +83,19 @@ const PodsTable = ({
         [theme],
     );
 
+    // Check if we have no pods at all or if pods exist but are filtered out
+    const noPodsAtAll = pods.length === 0;
+    const hasFilters = filters.status !== "All" || (filters.queue && filters.queue !== "All");
+    const hasNoResults = sortedPods.length === 0;
+
+    // Clear all filters function
+    const handleClearFilters = () => {
+        onFilterChange("status", "All");
+        if (filters.queue) {
+            onFilterChange("queue", "All");
+        }
+    };
+
     return (
         <TableContainer
             component={Paper}
@@ -92,6 +107,7 @@ const PodsTable = ({
                 background: `linear-gradient(to bottom, ${alpha(theme.palette.background.paper, 0.9)}, ${theme.palette.background.paper})`,
                 backdropFilter: "blur(10px)",
                 border: `1px solid ${alpha(theme.palette.divider, 0.1)}`,
+                transition: "all 0.3s ease",
                 "&::-webkit-scrollbar": {
                     width: "10px",
                     height: "10px",
@@ -120,14 +136,27 @@ const PodsTable = ({
                     sortDirection={sortDirection}
                 />
                 <TableBody>
-                    {sortedPods.map((pod) => (
-                        <PodRow
-                            key={`${pod.metadata.namespace}-${pod.metadata.name}`}
-                            pod={pod}
-                            getStatusColor={getStatusColor}
-                            onPodClick={onPodClick}
-                        />
-                    ))}
+                    {sortedPods.length > 0 ? (
+                        sortedPods.map((pod) => (
+                            <PodRow
+                                key={`${pod.metadata.namespace}-${pod.metadata.name}`}
+                                pod={pod}
+                                getStatusColor={getStatusColor}
+                                onPodClick={onPodClick}
+                            />
+                        ))
+                    ) : (
+                        <tr>
+                            <td colSpan="100%">
+                                <EmptyState
+                                    resourceType="Pod"
+                                    hasFilters={hasFilters && !noPodsAtAll}
+                                    onClearFilters={handleClearFilters}
+                                    onRefresh={onRefresh}
+                                />
+                            </td>
+                        </tr>
+                    )}
                 </TableBody>
             </Table>
         </TableContainer>

--- a/frontend/src/components/queues/QueueTable/QueueTable.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTable.jsx
@@ -10,9 +10,10 @@ import {
 import QueueTableHeader from "./QueueTableHeader";
 import QueueTableRow from "./QueueTableRow";
 import QueueTableDeleteDialog from "./QueueTableDeleteDialog";
+import EmptyState from "../../common/EmptyState";
 
 const QueueTable = ({
-    sortedQueues,
+    sortedQueues = [],
     allocatedFields,
     handleQueueClick,
     handleSort,
@@ -24,6 +25,7 @@ const QueueTable = ({
     handleFilterClose,
     setAnchorEl,
     handleDelete,
+    onRefresh,
 }) => {
     const theme = useTheme();
     const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
@@ -44,6 +46,20 @@ const QueueTable = ({
             handleDelete(queueToDelete);
         }
         handleCloseDeleteDialog();
+    };
+
+    // Check if filters are applied
+    const hasFilters = Object.entries(filters).some(([key, value]) => {
+        // Skip 'All' values or empty values
+        return value !== "All" && value !== "";
+    });
+
+    // Handle clearing all filters
+    const handleClearFilters = () => {
+        // Reset all filters to 'All' or empty
+        Object.keys(filters).forEach((key) => {
+            handleFilterClose(key, "All");
+        });
     };
 
     return (
@@ -94,15 +110,36 @@ const QueueTable = ({
                         setAnchorEl={setAnchorEl}
                     />
                     <TableBody>
-                        {sortedQueues.map((queue) => (
-                            <QueueTableRow
-                                key={queue.metadata.name}
-                                queue={queue}
-                                allocatedFields={allocatedFields}
-                                handleQueueClick={handleQueueClick}
-                                handleOpenDeleteDialog={handleOpenDeleteDialog}
-                            />
-                        ))}
+                        {sortedQueues.length > 0 ? (
+                            sortedQueues.map((queue) => (
+                                <QueueTableRow
+                                    key={queue.metadata.name}
+                                    queue={queue}
+                                    allocatedFields={allocatedFields}
+                                    handleQueueClick={handleQueueClick}
+                                    handleOpenDeleteDialog={
+                                        handleOpenDeleteDialog
+                                    }
+                                />
+                            ))
+                        ) : (
+                            <tr>
+                                <td colSpan="100%">
+                                    <EmptyState
+                                        resourceType="Queue"
+                                        hasFilters={hasFilters}
+                                        onClearFilters={handleClearFilters}
+                                        onRefresh={onRefresh}
+                                        customMessages={{
+                                            noDataDescription:
+                                                "There are currently no queues configured in the cluster.",
+                                            noMatchDescription:
+                                                "No queues match your current filter criteria. Try adjusting your filters to see more results.",
+                                        }}
+                                    />
+                                </td>
+                            </tr>
+                        )}
                     </TableBody>
                 </Table>
             </TableContainer>

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -242,6 +242,7 @@ const Queues = () => {
                 uniqueStates={uniqueStates}
                 handleFilterClose={handleFilterClose}
                 setAnchorEl={setAnchorEl}
+                onRefresh={handleRefresh}
             />
             <QueuePagination
                 pagination={pagination}


### PR DESCRIPTION
### UI Upgrade for Resource Tables

- Improved UX for resource tables (`Pods`, `Queues`, `Jobs`).
- Previously, empty tables only displayed headers when no resources were available, which was not user-friendly.
- Updates include:
  - Display a **"No resources available"** message when table data is empty.
  - If filters are applied, show **"No results match your filter"** with a **Clear Filter** button.
  - When no resources are available without filters, provide a **Refresh** button to retry fetching data.
- Created a **reusable EmptyState component** used across all resource tables to maintain consistency and reduce duplication.


Screenshot : 
![Screenshot from 2025-05-14 19-27-11](https://github.com/user-attachments/assets/f91aea89-b637-4e77-8d8e-7fef982fa667)

![Screenshot from 2025-05-14 19-26-58](https://github.com/user-attachments/assets/0b33db88-e3a7-4d69-b383-fdb466826118)

