### PR TITLE
Add form-based editor for Jobs (frontend)

### DIFF
--- a/frontend/src/components/jobs/JobDialog.jsx
+++ b/frontend/src/components/jobs/JobDialog.jsx
@@ -1,85 +1,335 @@
-import React from "react";
+import React, { useState } from 'react';
 import {
-    Box,
-    Button,
-    Dialog,
-    DialogActions,
-    DialogContent,
-    DialogTitle,
-} from "@mui/material";
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Box,
+  Button,
+  Tabs,
+  Tab,
+  IconButton,
+  Tooltip,
+} from '@mui/material';
+import CodeIcon from '@mui/icons-material/Code';
+import FormatListBulletedIcon from '@mui/icons-material/FormatListBulleted';
+import SaveIcon from '@mui/icons-material/Save';
+import CloseIcon from '@mui/icons-material/Close';
+import JobForm from './JobForm';
+import axios from 'axios';
+import YAML from 'yaml';
 
-const JobDialog = ({ open, handleClose, selectedJobName, selectedJobYaml }) => {
-    return (
-        <Dialog
-            open={open}
-            onClose={handleClose}
-            maxWidth={false}
-            fullWidth
-            PaperProps={{
-                sx: {
-                    width: "80%",
-                    maxWidth: "800px",
-                    maxHeight: "90vh",
-                    m: 2,
-                    bgcolor: "background.paper",
-                },
-            }}
-        >
-            <DialogTitle>Job YAML - {selectedJobName}</DialogTitle>
-            <DialogContent>
-                <Box
-                    sx={{
-                        mt: 2,
-                        mb: 2,
-                        fontFamily: "monospace",
-                        fontSize: "1.2rem",
-                        whiteSpace: "pre-wrap",
-                        overflow: "auto",
-                        maxHeight: "calc(90vh - 150px)",
-                        bgcolor: "grey.50",
-                        p: 2,
-                        borderRadius: 1,
-                        "& .yaml-key": {
-                            fontWeight: 700,
-                            color: "#000",
+/**
+ * Enhanced JobDialog that supports both viewing and editing Job resources
+ */
+const EnhancedJobDialog = ({ 
+  open, 
+  handleClose, 
+  selectedJobName, 
+  selectedJobYaml, 
+  selectedJobNamespace = 'default',
+  mode = 'view', // 'view', 'edit', or 'create'
+}) => {
+  const [activeTab, setActiveTab] = useState('form');
+  const [editableYaml, setEditableYaml] = useState(selectedJobYaml || '');
+  const [formData, setFormData] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // Convert HTML-formatted YAML to plain text and parse it
+  React.useEffect(() => {
+    if (selectedJobYaml) {
+      const plainYaml = selectedJobYaml.replace(/<span class="yaml-key">([^<]+)<\/span>/g, '$1');
+      setEditableYaml(plainYaml);
+      
+      try {
+        const parsed = YAML.parse(plainYaml);
+        setFormData(parsed);
+      } catch (err) {
+        console.error('Error parsing YAML:', err);
+        setError('Failed to parse YAML. The form view may not be available.');
+      }
+    } else if (mode === 'create') {
+      // Set default job template for creation
+      const defaultJob = {
+        apiVersion: 'batch.volcano.sh/v1alpha1',
+        kind: 'Job',
+        metadata: {
+          name: '',
+          namespace: selectedJobNamespace || 'default',
+        },
+        spec: {
+          minAvailable: 1,
+          schedulerName: 'volcano',
+          queue: 'default',
+          tasks: [
+            {
+              replicas: 1,
+              name: 'default',
+              template: {
+                spec: {
+                  containers: [
+                    {
+                      name: 'container',
+                      image: 'nginx:latest',
+                      resources: {
+                        requests: {
+                          cpu: '100m',
+                          memory: '100Mi',
                         },
-                    }}
-                >
-                    <pre
-                        dangerouslySetInnerHTML={{
-                            __html: selectedJobYaml,
-                        }}
-                    />
-                </Box>
-            </DialogContent>
-            <DialogActions>
-                <Box
-                    sx={{
-                        display: "flex",
-                        justifyContent: "flex-end",
-                        mt: 2,
-                        width: "100%",
-                        px: 2,
-                        pb: 2,
-                    }}
-                >
-                    <Button
-                        variant="contained"
-                        color="primary"
-                        onClick={handleClose}
-                        sx={{
-                            minWidth: "100px",
-                            "&:hover": {
-                                bgcolor: "primary.dark",
-                            },
-                        }}
-                    >
-                        Close
-                    </Button>
-                </Box>
-            </DialogActions>
-        </Dialog>
-    );
+                        limits: {
+                          cpu: '1000m',
+                          memory: '1Gi',
+                        },
+                      },
+                    },
+                  ],
+                  restartPolicy: 'Never',
+                },
+              },
+            },
+          ],
+        },
+      };
+      setFormData(defaultJob);
+      setEditableYaml(YAML.stringify(defaultJob));
+    }
+  }, [selectedJobYaml, mode, selectedJobNamespace]);
+
+  // Handle tab change
+  const handleTabChange = (event, newValue) => {
+    if (newValue === 'yaml' && activeTab === 'form') {
+      // Form to YAML - update YAML from form data
+      try {
+        setEditableYaml(YAML.stringify(formData));
+      } catch (err) {
+        console.error('Error converting form data to YAML:', err);
+      }
+    } else if (newValue === 'form' && activeTab === 'yaml') {
+      // YAML to form - parse YAML
+      try {
+        const parsed = YAML.parse(editableYaml);
+        setFormData(parsed);
+        setError(null);
+      } catch (err) {
+        setError('Invalid YAML. Please fix errors before switching to form view.');
+        return; // Don't change tabs if YAML is invalid
+      }
+    }
+    setActiveTab(newValue);
+  };
+
+  // Handle YAML text changes
+  const handleYamlChange = (event) => {
+    setEditableYaml(event.target.value);
+  };
+
+  // Handle form data changes
+  const handleFormChange = (newData) => {
+    setFormData(newData);
+  };
+
+  // Handle save
+  // In JobDialog.jsx
+  const handleSave = async () => {
+    setLoading(true);
+    setError(null);
+    
+    try {
+      const dataToSave = activeTab === 'form' 
+        ? formData 
+        : YAML.parse(editableYaml);
+      
+      // Log the data being sent
+      console.log('Saving job data:', JSON.stringify(dataToSave, null, 2));
+      
+      if (mode === 'edit') {
+        await axios.put(
+          `/api/job/${dataToSave.metadata.namespace}/${dataToSave.metadata.name}`,
+          dataToSave
+        );
+      } else if (mode === 'create') {
+        await axios.post(
+          `/api/jobs`,
+          dataToSave
+        );
+      }
+      
+      handleClose(true);
+    } catch (err) {
+      console.error('Error saving job:', err);
+      // Log more error details
+      if (err.response) {
+        console.error('Response error data:', err.response.data);
+      }
+      setError(err.response?.data?.message || err.message || 'Failed to save job');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isEditMode = mode === 'edit' || mode === 'create';
+  const dialogTitle = 
+    mode === 'view' ? `Job YAML - ${selectedJobName}` :
+    mode === 'edit' ? `Edit Job - ${selectedJobName}` :
+    'Create New Job';
+
+  return (
+    <Dialog
+      open={open}
+      onClose={handleClose}
+      maxWidth={false}
+      fullWidth
+      PaperProps={{
+        sx: {
+          width: '80%',
+          maxWidth: '900px',
+          maxHeight: '90vh',
+          m: 2,
+          bgcolor: 'background.paper',
+        },
+      }}
+    >
+      <DialogTitle sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        {dialogTitle}
+        <IconButton onClick={handleClose} aria-label="close">
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      
+      {isEditMode && (
+        <Tabs
+          value={activeTab}
+          onChange={handleTabChange}
+          sx={{ borderBottom: 1, borderColor: 'divider', px: 2 }}
+        >
+          <Tab 
+            value="form" 
+            label="Form View" 
+            icon={<FormatListBulletedIcon />} 
+            iconPosition="start" 
+          />
+          <Tab 
+            value="yaml" 
+            label="YAML View" 
+            icon={<CodeIcon />} 
+            iconPosition="start" 
+          />
+        </Tabs>
+      )}
+      
+      <DialogContent>
+        {error && (
+          <Box 
+            sx={{ 
+              p: 2, 
+              mb: 2, 
+              bgcolor: 'error.light', 
+              color: 'error.contrastText',
+              borderRadius: 1
+            }}
+          >
+            {error}
+          </Box>
+        )}
+        
+        {isEditMode && activeTab === 'form' ? (
+          // Form view
+          <Box sx={{ mt: 1 }}>
+            {formData && (
+              <JobForm 
+                data={formData} 
+                onChange={handleFormChange} 
+                disabled={loading}
+              />
+            )}
+          </Box>
+        ) : (
+          // YAML view - either editable in edit mode or read-only in view mode
+          <Box
+            sx={{
+              mt: 2,
+              mb: 2,
+              fontFamily: 'monospace',
+              fontSize: '1rem',
+              whiteSpace: 'pre-wrap',
+              overflow: 'auto',
+              maxHeight: 'calc(90vh - 200px)',
+              bgcolor: 'grey.50',
+              p: 2,
+              borderRadius: 1,
+            }}
+          >
+            {isEditMode ? (
+              <Box
+                component="textarea"
+                value={editableYaml}
+                onChange={handleYamlChange}
+                disabled={loading}
+                sx={{
+                  width: '100%',
+                  height: 'calc(90vh - 250px)',
+                  fontFamily: 'monospace',
+                  fontSize: '1rem',
+                  p: 2,
+                  border: '1px solid',
+                  borderColor: 'divider',
+                  borderRadius: 1,
+                  resize: 'none',
+                }}
+              />
+            ) : (
+              <pre
+                dangerouslySetInnerHTML={{
+                  __html: selectedJobYaml,
+                }}
+              />
+            )}
+          </Box>
+        )}
+      </DialogContent>
+      
+      <DialogActions>
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'flex-end',
+            mt: 2,
+            width: '100%',
+            px: 2,
+            pb: 2,
+          }}
+        >
+          <Button
+            variant="outlined"
+            onClick={handleClose}
+            sx={{ mr: 2 }}
+            disabled={loading}
+          >
+            {isEditMode ? 'Cancel' : 'Close'}
+          </Button>
+          
+          {isEditMode && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={handleSave}
+              disabled={loading}
+              startIcon={<SaveIcon />}
+              sx={{
+                minWidth: '100px',
+                '&:hover': {
+                  bgcolor: 'primary.dark',
+                },
+              }}
+            >
+              {loading ? 'Saving...' : 'Save'}
+            </Button>
+          )}
+        </Box>
+      </DialogActions>
+    </Dialog>
+  );
 };
 
-export default JobDialog;
+export default EnhancedJobDialog;

--- a/frontend/src/components/jobs/JobForm.jsx
+++ b/frontend/src/components/jobs/JobForm.jsx
@@ -1,0 +1,530 @@
+import React, { useState, useEffect } from 'react';
+import {
+  Box,
+  TextField,
+  Grid,
+  Typography,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+  Button,
+  IconButton,
+  Paper,
+  Alert,
+  Divider,
+} from '@mui/material';
+import AddIcon from '@mui/icons-material/Add';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+/**
+ * JobForm component for editing Job resources
+ */
+const JobForm = ({ data, onChange, disabled = false, mode = 'create' }) => {
+  const [nameError, setNameError] = useState('');
+  const [namespaces, setNamespaces] = useState(['default']);
+  const [queues, setQueues] = useState(['default']);
+  
+  // Determine if we're in edit mode
+  const isEditMode = mode === 'edit';
+  
+  // Fetch available namespaces and queues
+  useEffect(() => {
+    // In a real implementation, these would be API calls
+    // For now, we'll just mock some data
+    setNamespaces(['default', 'kube-system', 'volcano-system']);
+    setQueues(['default', 'high-priority', 'batch', 'test']);
+  }, []);
+
+  // Validate name field
+  useEffect(() => {
+    if (!data?.metadata?.name) {
+      setNameError('Name is required');
+    } else if (!/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/.test(data.metadata.name)) {
+      setNameError('Name must consist of lowercase alphanumeric characters or "-", and must start and end with an alphanumeric character');
+    } else {
+      setNameError('');
+    }
+  }, [data?.metadata?.name]);
+
+  // Deep clone to avoid direct mutation
+  const updateData = (path, value) => {
+    if (disabled) return;
+    
+    const newData = JSON.parse(JSON.stringify(data));
+    const pathParts = path.split('.');
+    
+    // Navigate to the nested object
+    let current = newData;
+    for (let i = 0; i < pathParts.length - 1; i++) {
+      const part = pathParts[i];
+      
+      // Handle array paths like tasks[0]
+      if (part.includes('[') && part.includes(']')) {
+        const arrName = part.substring(0, part.indexOf('['));
+        const index = parseInt(part.substring(part.indexOf('[') + 1, part.indexOf(']')));
+        
+        if (!current[arrName]) current[arrName] = [];
+        if (!current[arrName][index]) current[arrName][index] = {};
+        
+        current = current[arrName][index];
+      } else {
+        if (!current[part]) current[part] = {};
+        current = current[part];
+      }
+    }
+    
+    // Set the value
+    current[pathParts[pathParts.length - 1]] = value;
+    onChange(newData);
+  };
+
+  // Add a new task
+  const addTask = () => {
+    if (disabled || isEditMode) return;
+    
+    const newData = JSON.parse(JSON.stringify(data));
+    if (!newData.spec) newData.spec = {};
+    if (!newData.spec.tasks) newData.spec.tasks = [];
+    
+    newData.spec.tasks.push({
+      replicas: 1,
+      name: `task-${newData.spec.tasks.length + 1}`,
+      template: {
+        spec: {
+          containers: [
+            {
+              name: 'container',
+              image: 'nginx:latest',
+              resources: {
+                requests: {
+                  cpu: '100m',
+                  memory: '100Mi'
+                },
+                limits: {
+                  cpu: '1000m',
+                  memory: '1Gi'
+                }
+              }
+            }
+          ],
+          restartPolicy: 'Never'
+        }
+      }
+    });
+    
+    onChange(newData);
+  };
+
+  // Remove a task
+  const removeTask = (index) => {
+    if (disabled || isEditMode) return;
+    
+    const newData = JSON.parse(JSON.stringify(data));
+    newData.spec.tasks.splice(index, 1);
+    onChange(newData);
+  };
+
+  // Add a container to a task
+  const addContainer = (taskIndex) => {
+    if (disabled || isEditMode) return;
+    
+    const newData = JSON.parse(JSON.stringify(data));
+    const task = newData.spec.tasks[taskIndex];
+    
+    if (!task.template) task.template = {};
+    if (!task.template.spec) task.template.spec = {};
+    if (!task.template.spec.containers) task.template.spec.containers = [];
+    
+    task.template.spec.containers.push({
+      name: `container-${task.template.spec.containers.length + 1}`,
+      image: 'nginx:latest',
+      resources: {
+        requests: {
+          cpu: '100m',
+          memory: '100Mi'
+        },
+        limits: {
+          cpu: '1000m',
+          memory: '1Gi'
+        }
+      }
+    });
+    
+    onChange(newData);
+  };
+
+  // Remove a container
+  const removeContainer = (taskIndex, containerIndex) => {
+    if (disabled || isEditMode) return;
+    
+    const newData = JSON.parse(JSON.stringify(data));
+    newData.spec.tasks[taskIndex].template.spec.containers.splice(containerIndex, 1);
+    onChange(newData);
+  };
+
+  // Ensure default structure
+  useEffect(() => {
+    if (!data) return;
+    
+    const newData = { ...data };
+    
+    // Ensure required fields exist
+    if (!newData.apiVersion) newData.apiVersion = 'batch.volcano.sh/v1alpha1';
+    if (!newData.kind) newData.kind = 'Job';
+    if (!newData.metadata) newData.metadata = {};
+    if (!newData.spec) newData.spec = {};
+    if (!newData.spec.tasks) newData.spec.tasks = [];
+    
+    // If no tasks, add a default one
+    if (newData.spec.tasks.length === 0) {
+      newData.spec.tasks.push({
+        replicas: 1,
+        name: 'default',
+        template: {
+          spec: {
+            containers: [
+              {
+                name: 'container',
+                image: 'nginx:latest',
+                resources: {
+                  requests: {
+                    cpu: '100m',
+                    memory: '100Mi'
+                  },
+                  limits: {
+                    cpu: '1000m',
+                    memory: '1Gi'
+                  }
+                }
+              }
+            ],
+            restartPolicy: 'Never'
+          }
+        }
+      });
+    }
+    
+    // Set default scheduler and queue if not present
+    if (!newData.spec.schedulerName) newData.spec.schedulerName = 'volcano';
+    if (!newData.spec.queue) newData.spec.queue = 'default';
+    if (!newData.spec.minAvailable) newData.spec.minAvailable = 1;
+    
+    onChange(newData);
+  }, []);
+
+  if (!data) {
+    return <Typography>Loading...</Typography>;
+  }
+
+  return (
+    <Box sx={{ mt: 1 }}>
+      {/* Add warning message for edit mode */}
+      {isEditMode && (
+        <Alert severity="info" sx={{ mb: 3 }}>
+          Some fields cannot be modified after a job is created. Only the Queue field can be edited.
+        </Alert>
+      )}
+      
+      {/* Metadata Section */}
+      <Typography variant="h6" gutterBottom>
+        Metadata
+      </Typography>
+      
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={6}>
+          <TextField
+            label="Name"
+            fullWidth
+            required
+            value={data.metadata?.name || ''}
+            onChange={(e) => updateData('metadata.name', e.target.value)}
+            error={!!nameError}
+            helperText={nameError || (isEditMode ? "Cannot be changed after creation" : "")}
+            disabled={disabled || isEditMode} // Name can't be changed after creation
+          />
+        </Grid>
+        
+        <Grid item xs={12} md={6}>
+          <FormControl fullWidth disabled={disabled || isEditMode}> {/* Namespace can't be changed */}
+            <InputLabel id="namespace-label">Namespace</InputLabel>
+            <Select
+              labelId="namespace-label"
+              value={data.metadata?.namespace || 'default'}
+              label="Namespace"
+              onChange={(e) => updateData('metadata.namespace', e.target.value)}
+            >
+              {namespaces.map((ns) => (
+                <MenuItem key={ns} value={ns}>{ns}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {isEditMode && (
+            <Typography variant="caption" color="text.secondary">
+              Cannot be changed after creation
+            </Typography>
+          )}
+        </Grid>
+      </Grid>
+
+      <Divider sx={{ my: 2 }} />
+
+      {/* Job Settings Section */}
+      <Typography variant="h6" gutterBottom>
+        Job Settings
+      </Typography>
+      
+      <Grid container spacing={2} sx={{ mb: 3 }}>
+        <Grid item xs={12} md={4}>
+          <TextField
+            label="Minimum Available Pods"
+            type="number"
+            fullWidth
+            value={data.spec?.minAvailable || 1}
+            onChange={(e) => updateData('spec.minAvailable', parseInt(e.target.value) || 1)}
+            inputProps={{ min: 1 }}
+            disabled={disabled || isEditMode} // Can't change minAvailable after creation
+            helperText={isEditMode ? "Cannot be changed after creation" : ""}
+          />
+        </Grid>
+        
+        <Grid item xs={12} md={4}>
+          <FormControl fullWidth disabled={disabled}>
+            <InputLabel id="queue-label">Queue</InputLabel>
+            <Select
+              labelId="queue-label"
+              value={data.spec?.queue || 'default'}
+              label="Queue"
+              onChange={(e) => updateData('spec.queue', e.target.value)}
+            >
+              {queues.map((queue) => (
+                <MenuItem key={queue} value={queue}>{queue}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          {isEditMode && (
+            <Typography variant="caption" color="text.secondary" sx={{ color: 'green' }}>
+              This field can be changed
+            </Typography>
+          )}
+        </Grid>
+        
+        <Grid item xs={12} md={4}>
+          <TextField
+            label="Scheduler Name"
+            fullWidth
+            value={data.spec?.schedulerName || 'volcano'}
+            onChange={(e) => updateData('spec.schedulerName', e.target.value)}
+            disabled={disabled || isEditMode} // Can't change scheduler after creation
+            helperText={isEditMode ? "Cannot be changed after creation" : ""}
+          />
+        </Grid>
+      </Grid>
+
+      <Divider sx={{ my: 2 }} />
+
+      {/* Tasks Section */}
+      <Box sx={{ mb: 3 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          <Typography variant="h6">
+            Tasks
+          </Typography>
+          <Button
+            variant="outlined"
+            startIcon={<AddIcon />}
+            onClick={addTask}
+            disabled={disabled || isEditMode} // Can't add tasks after creation
+          >
+            Add Task
+          </Button>
+        </Box>
+        
+        {isEditMode && (
+          <Typography variant="caption" color="text.secondary" sx={{ display: 'block', mb: 2 }}>
+            Tasks cannot be added, removed, or modified after job creation
+          </Typography>
+        )}
+        
+        {data.spec?.tasks?.map((task, taskIndex) => (
+          <Paper 
+            key={taskIndex} 
+            elevation={2} 
+            sx={{ p: 2, mb: 2, opacity: isEditMode ? 0.9 : 1 }}
+          >
+            <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+              <Typography variant="subtitle1">
+                Task: {task.name || `Task ${taskIndex + 1}`}
+              </Typography>
+              {!disabled && !isEditMode && (
+                <IconButton
+                  edge="end"
+                  color="error"
+                  onClick={() => removeTask(taskIndex)}
+                  disabled={data.spec.tasks.length <= 1 || isEditMode}
+                >
+                  <DeleteIcon />
+                </IconButton>
+              )}
+            </Box>
+            
+            <Grid container spacing={2} sx={{ mb: 2 }}>
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Task Name"
+                  fullWidth
+                  required
+                  value={task.name || ''}
+                  onChange={(e) => updateData(`spec.tasks[${taskIndex}].name`, e.target.value)}
+                  disabled={disabled || isEditMode} // Can't change task name after creation
+                />
+              </Grid>
+              
+              <Grid item xs={12} md={6}>
+                <TextField
+                  label="Replicas"
+                  type="number"
+                  fullWidth
+                  value={task.replicas || 1}
+                  onChange={(e) => updateData(`spec.tasks[${taskIndex}].replicas`, parseInt(e.target.value) || 1)}
+                  inputProps={{ min: 1 }}
+                  disabled={disabled || isEditMode} // Can't change replicas after creation
+                />
+              </Grid>
+            </Grid>
+            
+            <Box sx={{ mb: 2 }}>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+                <Typography variant="subtitle2">
+                  Containers
+                </Typography>
+                <Button
+                  variant="outlined"
+                  size="small"
+                  startIcon={<AddIcon />}
+                  onClick={() => addContainer(taskIndex)}
+                  disabled={disabled || isEditMode} // Can't add containers after creation
+                >
+                  Add Container
+                </Button>
+              </Box>
+              
+              {task.template?.spec?.containers?.map((container, containerIndex) => (
+                <Paper 
+                  key={containerIndex} 
+                  variant="outlined" 
+                  sx={{ p: 2, mb: 2 }}
+                >
+                  <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+                    <Typography variant="body1">
+                      Container {containerIndex + 1}
+                    </Typography>
+                    {!disabled && !isEditMode && (
+                      <IconButton
+                        edge="end"
+                        size="small"
+                        color="error"
+                        onClick={() => removeContainer(taskIndex, containerIndex)}
+                        disabled={task.template.spec.containers.length <= 1 || isEditMode}
+                      >
+                        <DeleteIcon />
+                      </IconButton>
+                    )}
+                  </Box>
+                  
+                  <Grid container spacing={2} sx={{ mb: 2 }}>
+                    <Grid item xs={12} md={6}>
+                      <TextField
+                        label="Container Name"
+                        fullWidth
+                        required
+                        value={container.name || ''}
+                        onChange={(e) => updateData(`spec.tasks[${taskIndex}].template.spec.containers[${containerIndex}].name`, e.target.value)}
+                        disabled={disabled || isEditMode} // Can't change container name after creation
+                      />
+                    </Grid>
+                    
+                    <Grid item xs={12} md={6}>
+                      <TextField
+                        label="Image"
+                        fullWidth
+                        required
+                        value={container.image || ''}
+                        onChange={(e) => updateData(`spec.tasks[${taskIndex}].template.spec.containers[${containerIndex}].image`, e.target.value)}
+                        placeholder="nginx:latest"
+                        disabled={disabled || isEditMode} // Can't change image after creation
+                      />
+                    </Grid>
+                  </Grid>
+                  
+                  <Typography variant="subtitle2" gutterBottom>
+                    Resource Requests & Limits
+                  </Typography>
+                  
+                  <Grid container spacing={2}>
+                    <Grid item xs={12} sm={6} md={3}>
+                      <TextField
+                        label="CPU Requests"
+                        fullWidth
+                        value={container.resources?.requests?.cpu || '100m'}
+                        onChange={(e) => updateData(`spec.tasks[${taskIndex}].template.spec.containers[${containerIndex}].resources.requests.cpu`, e.target.value)}
+                        placeholder="100m"
+                        disabled={disabled || isEditMode} // Can't change resources after creation
+                      />
+                    </Grid>
+                    
+                    <Grid item xs={12} sm={6} md={3}>
+                      <TextField
+                        label="Memory Requests"
+                        fullWidth
+                        value={container.resources?.requests?.memory || '100Mi'}
+                        onChange={(e) => updateData(`spec.tasks[${taskIndex}].template.spec.containers[${containerIndex}].resources.requests.memory`, e.target.value)}
+                        placeholder="100Mi"
+                        disabled={disabled || isEditMode} // Can't change resources after creation
+                      />
+                    </Grid>
+                    
+                    <Grid item xs={12} sm={6} md={3}>
+                      <TextField
+                        label="CPU Limits"
+                        fullWidth
+                        value={container.resources?.limits?.cpu || '1000m'}
+                        onChange={(e) => updateData(`spec.tasks[${taskIndex}].template.spec.containers[${containerIndex}].resources.limits.cpu`, e.target.value)}
+                        placeholder="1000m"
+                        disabled={disabled || isEditMode} // Can't change resources after creation
+                      />
+                    </Grid>
+                    
+                    <Grid item xs={12} sm={6} md={3}>
+                      <TextField
+                        label="Memory Limits"
+                        fullWidth
+                        value={container.resources?.limits?.memory || '1Gi'}
+                        onChange={(e) => updateData(`spec.tasks[${taskIndex}].template.spec.containers[${containerIndex}].resources.limits.memory`, e.target.value)}
+                        placeholder="1Gi"
+                        disabled={disabled || isEditMode} // Can't change resources after creation
+                      />
+                    </Grid>
+                  </Grid>
+                </Paper>
+              ))}
+              
+              {(!task.template?.spec?.containers || task.template.spec.containers.length === 0) && (
+                <Alert severity="warning">
+                  At least one container is required
+                </Alert>
+              )}
+            </Box>
+          </Paper>
+        ))}
+        
+        {(!data.spec?.tasks || data.spec.tasks.length === 0) && (
+          <Alert severity="warning">
+            At least one task is required
+          </Alert>
+        )}
+      </Box>
+    </Box>
+  );
+};
+
+export default JobForm;

--- a/frontend/src/components/jobs/JobTable/JobEditDialog.jsx
+++ b/frontend/src/components/jobs/JobTable/JobEditDialog.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useRef } from "react";
 import {
     Dialog,
     DialogTitle,
@@ -7,35 +7,253 @@ import {
     Button,
     ToggleButton,
     ToggleButtonGroup,
+    Box,
+    CircularProgress,
+    TextField,
+    Checkbox,
+    FormControlLabel,
+    Typography
 } from "@mui/material";
 import Editor from "@monaco-editor/react";
 import yaml from "js-yaml";
 
+const RenderFields = ({ data, onChange, path = [] }) =>
+    Object.entries(data || {}).map(([key, value]) => {
+        if (key === "managedFields" || key.startsWith("f:")) return null;
+
+        const currentPath = [...path, key];
+
+        if (Array.isArray(value)) {
+            return (
+                <Box
+                    key={currentPath.join(".")}
+                    sx={{ mb: 2, pl: 2, borderLeft: "2px solid #ccc" }}
+                >
+                    <Typography variant="subtitle2">{key} (Array)</Typography>
+                    {value.map((item, index) => {
+                        const itemPath = [...currentPath, index];
+                        if (typeof item === "object" && item !== null) {
+                            return (
+                                <Box
+                                    key={itemPath.join(".")}
+                                    sx={{
+                                        pl: 2,
+                                        mb: 1,
+                                        borderLeft: "1px dashed #999",
+                                    }}
+                                >
+                                    <Typography variant="caption">
+                                        Item {index}
+                                    </Typography>
+                                    <RenderFields
+                                        data={item}
+                                        onChange={onChange}
+                                        path={itemPath}
+                                    />
+                                </Box>
+                            );
+                        }
+                        return (
+                            <TextField
+                                key={itemPath.join(".")}
+                                label={`${key}[${index}]`}
+                                value={item}
+                                fullWidth
+                                margin="dense"
+                                onChange={(e) => {
+                                    let val = e.target.value;
+                                    if (val === "true") val = true;
+                                    else if (val === "false") val = false;
+                                    else if (!isNaN(val) && val.trim() !== "")
+                                        val = Number(val);
+                                    onChange(itemPath, val);
+                                }}
+                            />
+                        );
+                    })}
+                </Box>
+            );
+        }
+
+        if (typeof value === "object" && value !== null) {
+            return (
+                <Box
+                    key={currentPath.join(".")}
+                    sx={{ mb: 2, pl: 2, borderLeft: "2px solid #ccc" }}
+                >
+                    <Typography variant="subtitle2">{key}</Typography>
+                    <RenderFields
+                        data={value}
+                        onChange={onChange}
+                        path={currentPath}
+                    />
+                </Box>
+            );
+        }
+
+        // Render checkbox for booleans
+        if (typeof value === "boolean") {
+            return (
+                <FormControlLabel
+                    key={currentPath.join(".")}
+                    control={
+                        <Checkbox
+                            checked={value}
+                            onChange={(e) =>
+                                onChange(currentPath, e.target.checked)
+                            }
+                        />
+                    }
+                    label={currentPath.join(".")}
+                    sx={{ mb: 1 }}
+                />
+            );
+        }
+
+        // For other primitives
+        return (
+            <TextField
+                key={currentPath.join(".")}
+                label={currentPath.join(".")}
+                value={value}
+                fullWidth
+                margin="dense"
+                onChange={(e) => {
+                    let val = e.target.value;
+                    if (val === "true") val = true;
+                    else if (val === "false") val = false;
+                    else if (!isNaN(val) && val.trim() !== "")
+                        val = Number(val);
+                    onChange(currentPath, val);
+                }}
+            />
+        );
+    });
+
+const updateNestedValue = (obj, path, value) => {
+    const newObj = { ...obj };
+    let current = newObj;
+    for (let i = 0; i < path.length - 1; i++) {
+        const key = path[i];
+        if (!(key in current)) current[key] = {};
+        current = current[key];
+    }
+    current[path[path.length - 1]] = value;
+    return newObj;
+};
+
 const JobEditDialog = ({ open, job, onClose, onSave }) => {
     const [editorValue, setEditorValue] = useState("");
     const [editMode, setEditMode] = useState("yaml");
+    const [formState, setFormState] = useState({});
+    const [saving, setSaving] = useState(false);
 
+    // Refs to avoid infinite loops when syncing form & YAML
+    const skipYamlUpdate = useRef(false);
+    const skipFormUpdate = useRef(false);
+
+    // Load initial data on open
     useEffect(() => {
         if (open && job) {
-            const initialContent = yaml.dump(job); // Always keep YAML content
-            setEditorValue(initialContent);
+            const dumpedYaml = yaml.dump(job);
+            setEditorValue(dumpedYaml);
+            setFormState(job);
+            setEditMode("yaml");
         }
     }, [open, job]);
 
-    const handleModeChange = (event, newMode) => {
-        if (newMode !== null) {
-            setEditMode(newMode); // Only change syntax highlighting
+    // Sync YAML editor -> formState (parse YAML)
+    useEffect(() => {
+        if (skipYamlUpdate.current) {
+            skipYamlUpdate.current = false;
+            return;
         }
+        try {
+            const parsed = yaml.load(editorValue) || {};
+            skipFormUpdate.current = true;
+            setFormState(parsed);
+        } catch {
+            // Ignore YAML parse errors, keep old formState
+        }
+    }, [editorValue]);
+
+    // Sync formState -> YAML editor (stringify)
+    useEffect(() => {
+        if (skipFormUpdate.current) {
+            skipFormUpdate.current = false;
+            return;
+        }
+        try {
+            const dumped = yaml.dump(formState);
+            skipYamlUpdate.current = true;
+            setEditorValue(dumped);
+        } catch {
+            // Ignore errors
+        }
+    }, [formState]);
+
+    const handleModeChange = (_, newMode) => {
+        if (!newMode) return;
+        setEditMode(newMode);
     };
 
-    const handleSave = () => {
+    const handleNestedChange = (path, value) => {
+        setFormState((prev) => updateNestedValue(prev, path, value));
+    };
+
+    const handleSave = async () => {
         try {
-            const updatedJob = yaml.load(editorValue); // Always parse as YAML
-            onSave(updatedJob);
+            const updated = 
+                editMode === "yaml" ? yaml.load(editorValue) : formState;
+
+            if (!updated?.metadata?.name || !updated?.metadata?.namespace) {
+                throw new Error("Job metadata.name or namespace is missing");
+            }
+
+            if (!updated.spec || Object.keys(updated.spec).length === 0) {
+                throw new Error("Job spec is empty or missing");
+            }
+
+            setSaving(true);
+
+            const resp = await fetch(`/api/job/${updated.metadata.namespace}/${updated.metadata.name}`, {
+                method: "PUT",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ spec: updated.spec }),
+            });
+
+            if (!resp.ok) {
+                const contentType = resp.headers.get("content-type");
+                const errText = contentType?.includes("application/json")
+                    ? (await resp.json()).details || "Unknown error"
+                    : await resp.text();
+                throw new Error(errText);
+            }
+
+            const responseData = await resp.json();
+
+            // Update local state with the response data from server
+            const fullUpdatedJob = {
+                ...updated,
+                spec: responseData.spec || updated.spec,
+            };
+
+            // Prevent infinite loops while syncing
+            skipFormUpdate.current = true;
+            setFormState(fullUpdatedJob);
+            skipYamlUpdate.current = true;
+            setEditorValue(yaml.dump(fullUpdatedJob));
+
+            if (typeof onSave === "function") {
+                onSave(responseData);
+            }
+
             onClose();
         } catch (err) {
-            console.error("Parsing error:", err);
-            alert("Invalid YAML format. Please check your input.");
+            console.error("Save failed:", err);
+            alert(err.message || "Failed to save");
+        } finally {
+            setSaving(false);
         }
     };
 
@@ -48,7 +266,7 @@ const JobEditDialog = ({ open, job, onClose, onSave }) => {
                     alignItems: "center",
                 }}
             >
-                Edit Job
+                Edit Job: {job?.metadata?.name}
                 <ToggleButtonGroup
                     value={editMode}
                     exclusive
@@ -56,30 +274,47 @@ const JobEditDialog = ({ open, job, onClose, onSave }) => {
                     color="primary"
                 >
                     <ToggleButton value="yaml">YAML</ToggleButton>
+                    <ToggleButton value="form">Form</ToggleButton>
                 </ToggleButtonGroup>
             </DialogTitle>
             <DialogContent sx={{ height: "500px" }}>
-                <Editor
-                    height="100%"
-                    language={editMode} // Just controls syntax highlight
-                    value={editorValue}
-                    onChange={(val) => setEditorValue(val || "")}
-                    options={{
-                        minimap: { enabled: false },
-                        automaticLayout: true,
-                    }}
-                />
+                {editMode === "yaml" ? (
+                    <Editor
+                        height="100%"
+                        language="yaml"
+                        value={editorValue}
+                        onChange={(val) => setEditorValue(val || "")}
+                        options={{
+                            minimap: { enabled: false },
+                            automaticLayout: true,
+                        }}
+                    />
+                ) : (
+                    <Box sx={{ mt: 2, overflow: "auto", maxHeight: "460px" }}>
+                        <RenderFields
+                            data={formState}
+                            onChange={handleNestedChange}
+                        />
+                    </Box>
+                )}
             </DialogContent>
             <DialogActions>
-                <Button onClick={onClose} color="primary" variant="contained">
+                <Button
+                    onClick={onClose}
+                    color="primary"
+                    variant="contained"
+                    disabled={saving}
+                >
                     Cancel
                 </Button>
                 <Button
                     onClick={handleSave}
                     color="primary"
                     variant="contained"
+                    disabled={saving}
+                    startIcon={saving && <CircularProgress size={18} />}
                 >
-                    Update
+                    {saving ? "Updating…" : "Update"}
                 </Button>
             </DialogActions>
         </Dialog>

--- a/frontend/src/components/jobs/JobTable/JobTable.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTable.jsx
@@ -22,9 +22,11 @@ const JobTable = ({
     handleFilterClose,
     sortDirection,
     toggleSortDirection,
+    onEditJob,
 }) => {
     const theme = useTheme();
-
+     
+    const handleOpenDeleteDialog = () => {};
     return (
         <TableContainer
             component={Paper}
@@ -71,6 +73,8 @@ const JobTable = ({
                             key={`${job.metadata.namespace}-${job.metadata.name}`}
                             job={job}
                             handleJobClick={handleJobClick}
+                            handleOpenDeleteDialog={handleOpenDeleteDialog}
+                            onEditJob={onEditJob}
                         />
                     ))}
                 </TableBody>

--- a/frontend/src/components/jobs/JobTable/JobTableRow.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTableRow.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
     TableRow,
     TableCell,
@@ -9,30 +9,14 @@ import {
 } from "@mui/material";
 import { Edit, Delete } from "@mui/icons-material";
 import JobStatusChip from "../JobStatusChip";
-import JobEditDialog from "./JobEditDialog"; // Create or import this component
 
 const JobTableRow = ({
     job,
     handleJobClick,
     handleOpenDeleteDialog,
-    onJobUpdate, // Function to update job after edit
+    onEditJob, 
 }) => {
     const theme = useTheme();
-    const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
-
-    const handleOpenEditDialog = (e) => {
-        e.stopPropagation();
-        setIsEditDialogOpen(true);
-    };
-
-    const handleCloseEditDialog = () => {
-        setIsEditDialogOpen(false);
-    };
-
-    const handleSaveJob = (updatedJob) => {
-        onJobUpdate(updatedJob);
-        handleCloseEditDialog();
-    };
 
     return (
         <>
@@ -132,7 +116,10 @@ const JobTableRow = ({
                 <TableCell sx={{ padding: "16px 24px" }}>
                     <Box display="flex" alignItems="center" gap={2}>
                         <IconButton
-                            onClick={handleOpenEditDialog}
+                            onClick={(e) => {
+                                e.stopPropagation();
+                                onEditJob(job); 
+                            }}
                             size="small"
                             sx={{
                                 color: theme.palette.primary.main,
@@ -168,14 +155,6 @@ const JobTableRow = ({
                     </Box>
                 </TableCell>
             </TableRow>
-
-            {/* Edit Dialog */}
-            <JobEditDialog
-                open={isEditDialogOpen}
-                job={job}
-                onClose={handleCloseEditDialog}
-                onSave={handleSaveJob}
-            />
         </>
     );
 };


### PR DESCRIPTION
# Form-Based Editor for Job Resources in Volcano Dashboard (Frontend Implementation)

This PR implements the frontend portion of a form-based editor for Job resources in the Volcano dashboard, providing a more user-friendly alternative to YAML editing.

## Status

- ✅ Frontend implementation complete
- ⏳ Backend implementation pending (will be added in a follow-up PR)

## Key Changes

- Added a form-based editor as an alternative to YAML editing for jobs
- Created a toggle between YAML and form views in the job editing interface
- Implemented automatic synchronization between form values and YAML content
- Added support for various data types (strings, numbers, booleans, arrays, objects)
- Enhanced error handling and validation for the job editing process
- Added loading indicators during update operations

## Backend Work Needed

The following backend endpoint needs to be implemented to complete this feature:

The following backend endpoints need to be implemented to complete this feature:

```javascript
// For updating existing jobs
app.put("/api/job/:namespace/:name", express.json(), async (req, res) => {
    // Implementation will be added in a follow-up PR
});

// For creating new jobs
app.post("/api/jobs", express.json(), async (req, res) => {
    // Implementation will be added in a follow-up PR
});

```

<img width="899" alt="Screenshot 2025-05-26 at 12 02 46 AM" src="https://github.com/user-attachments/assets/cba01ba2-b033-4124-929b-1178aac81eb6" />
<img width="899" alt="Screenshot 2025-05-26 at 12 02 49 AM" src="https://github.com/user-attachments/assets/ebebff5e-254b-4eea-a573-594c216734f3" />