### PR TITLE
Implement Queue View Toggle and Export Functionality

### DIFF
--- a/frontend/src/components/queues/QueuePagination.jsx
+++ b/frontend/src/components/queues/QueuePagination.jsx
@@ -1,12 +1,22 @@
-import React from "react";
-import { Box, Typography, Pagination, Select, MenuItem } from "@mui/material";
+import React, { useState } from "react";
+import { Box, Typography, Pagination, Select, MenuItem, Button, Tooltip } from "@mui/material";
+import { Download, List, Grid as GridIcon } from "lucide-react";
 
 const QueuePagination = ({
     pagination,
     totalQueues,
     handleChangeRowsPerPage,
     handleChangePage,
+    onExportQueues, // New prop for export functionality
+    onToggleViewMode // New prop for toggling view mode
 }) => {
+    const [viewMode, setViewMode] = useState("table"); // "table" or "grid"
+    
+    const handleViewModeChange = (mode) => {
+        setViewMode(mode);
+        onToggleViewMode(mode);
+    };
+
     return (
         <Box
             sx={{
@@ -16,15 +26,55 @@ const QueuePagination = ({
                 alignItems: "center",
             }}
         >
-            <Select
-                value={pagination.rowsPerPage}
-                onChange={handleChangeRowsPerPage}
-                size="small"
-            >
-                <MenuItem value={5}>5 per page</MenuItem>
-                <MenuItem value={10}>10 per page</MenuItem>
-                <MenuItem value={20}>20 per page</MenuItem>
-            </Select>
+            <Box display="flex" alignItems="center">
+                <Select
+                    value={pagination.rowsPerPage}
+                    onChange={handleChangeRowsPerPage}
+                    size="small"
+                >
+                    <MenuItem value={5}>5 per page</MenuItem>
+                    <MenuItem value={10}>10 per page</MenuItem>
+                    <MenuItem value={20}>20 per page</MenuItem>
+                </Select>
+                
+                {/* View mode toggle buttons */}
+                <Box ml={2} display="flex" alignItems="center">
+                    <Tooltip title="Table View">
+                        <Button 
+                            variant={viewMode === "table" ? "contained" : "outlined"}
+                            size="small"
+                            sx={{ minWidth: '40px', p: 1, mr: 1 }}
+                            onClick={() => handleViewModeChange("table")}
+                        >
+                            <List size={16} />
+                        </Button>
+                    </Tooltip>
+                    <Tooltip title="Grid View">
+                        <Button 
+                            variant={viewMode === "grid" ? "contained" : "outlined"}
+                            size="small"
+                            sx={{ minWidth: '40px', p: 1 }}
+                            onClick={() => handleViewModeChange("grid")}
+                        >
+                            <GridIcon size={16} />
+                        </Button>
+                    </Tooltip>
+                </Box>
+                
+                {/* Export button */}
+                <Tooltip title="Export Queues">
+                    <Button
+                        variant="outlined"
+                        size="small"
+                        startIcon={<Download size={16} />}
+                        onClick={onExportQueues}
+                        sx={{ ml: 2 }}
+                    >
+                        Export
+                    </Button>
+                </Tooltip>
+            </Box>
+            
             <Box
                 sx={{
                     display: "flex",

--- a/frontend/src/components/queues/QueueTable/QueueGridView.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueGridView.jsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { 
+  Box, 
+  Grid, 
+  Card, 
+  CardContent, 
+  Typography, 
+  Chip,
+  Divider
+} from "@mui/material";
+
+const QueueGridView = ({ queues, handleQueueClick }) => {
+  // Helper function to determine status color
+  const getStatusColor = (status) => {
+    switch (status?.toLowerCase()) {
+      case "open":
+        return "success";
+      case "closed":
+        return "error";
+      case "pending":
+        return "warning";
+      default:
+        return "default";
+    }
+  };
+
+  return (
+    <Box sx={{ flexGrow: 1, mt: 2 }}>
+      <Grid container spacing={2}>
+        {queues.map((queue) => (
+          <Grid item xs={12} sm={6} md={4} lg={3} key={queue.metadata.name}>
+            <Card 
+              sx={{ 
+                height: '100%', 
+                cursor: 'pointer',
+                transition: 'transform 0.2s, box-shadow 0.2s',
+                '&:hover': {
+                  transform: 'translateY(-4px)',
+                  boxShadow: 3
+                }
+              }}
+              onClick={() => handleQueueClick(queue)}
+            >
+              <CardContent>
+                <Box display="flex" justifyContent="space-between" alignItems="center" mb={1}>
+                  <Typography variant="h6" component="div" noWrap>
+                    {queue.metadata.name}
+                  </Typography>
+                  <Chip 
+                    label={queue.status?.state || "Unknown"} 
+                    size="small" 
+                    color={getStatusColor(queue.status?.state)}
+                  />
+                </Box>
+                
+                <Typography variant="body2" color="text.secondary" gutterBottom>
+                  Namespace: {queue.metadata.namespace || "default"}
+                </Typography>
+                
+                <Divider sx={{ my: 1.5 }} />
+                
+                <Typography variant="subtitle2">
+                  Allocated Resources:
+                </Typography>
+                
+                <Box mt={1}>
+                  <Typography variant="body2">
+                    CPU: {queue.status?.allocated?.cpu || "N/A"}
+                  </Typography>
+                  <Typography variant="body2">
+                    Memory: {queue.status?.allocated?.memory || "N/A"}
+                  </Typography>
+                  <Typography variant="body2">
+                    Pods: {queue.status?.allocated?.pods || "N/A"}
+                  </Typography>
+                </Box>
+                
+                <Divider sx={{ my: 1.5 }} />
+                
+                <Typography variant="caption" color="text.secondary">
+                  Created: {new Date(queue.metadata.creationTimestamp).toLocaleDateString()}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        ))}
+      </Grid>
+    </Box>
+  );
+};
+
+export default QueueGridView;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
                 "@mui/material": "^6.4.8",
                 "bootstrap": "^5.3.3",
                 "fortawesome": "^0.0.1-security",
+                "lucide-react": "^0.511.0",
                 "react-bootstrap": "^2.10.9"
             },
             "devDependencies": {
@@ -8804,6 +8805,14 @@
             "license": "ISC",
             "dependencies": {
                 "yallist": "^3.0.2"
+            }
+        },
+        "node_modules/lucide-react": {
+            "version": "0.511.0",
+            "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.511.0.tgz",
+            "integrity": "sha512-VK5a2ydJ7xm8GvBeKLS9mu1pVK6ucef9780JVUjw6bAjJL/QXnd4Y0p7SPeOUMC27YhzNCZvm5d/QX0Tp3rc0w==",
+            "peerDependencies": {
+                "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
             }
         },
         "node_modules/lz-string": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
         "@mui/material": "^6.4.8",
         "bootstrap": "^5.3.3",
         "fortawesome": "^0.0.1-security",
+        "lucide-react": "^0.511.0",
         "react-bootstrap": "^2.10.9"
     }
 }


### PR DESCRIPTION
### **Description**
The current Volcano Dashboard queue management interface uses a table-only view which limits visualization options and lacks data export capabilities. These limitations affect user experience, particularly for users who need to:

- Quickly scan multiple queues at once
- Share queue data with team members or use in reports
- Adapt the interface to their personal preferences or specific use cases
### **Solution**

- **View Toggle (Table/Grid)**: Allow users to switch between the traditional table view and a modern card-based grid view
- **Export Functionality**: Add the ability to export queue data as CSV
### **Screenshots**
![image](https://github.com/user-attachments/assets/059dc664-362f-48d6-afa1-a1734a877b3a)
![image](https://github.com/user-attachments/assets/22b07b57-0797-4842-8c20-f00346e40e8a)
![image](https://github.com/user-attachments/assets/508a9ac3-82d3-4768-910c-2de56979ef1e)
