### PR TITLE
docs: moved Getting Started section from CONTRIBUTING.md to README.md - Fixes: #68

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,7 @@ There are various ways in which you can contribute to this project such as `upda
 
 When making any critical change to this repository, please first discuss the change you wish to make via issue, email, or any other method with the [owners](https://github.com/volcano-sh/dashboard/blob/main/OWNERS) of this repository before making a change.
 
-## Getting Started
-
-Make sure [`node.js`](https://nodejs.org/en/download) is installed on your system and we prefer [`visual-studio-code`](https://code.visualstudio.com/download) as IDE.
+🚀 For dashboard setup, see the [Getting Started](./README.md#getting-started) section in README.
 
 ### Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ The volcano dashboard provides a basic dashboard that can be easily deployed in 
 
 <img src="docs/images/demo.gif" alt="volcano dashboard" style="zoom:50%;" />
 
+## Getting Started
+
+Make sure [`node.js`](https://nodejs.org/en/download) is installed on your system and we prefer [`visual-studio-code`](https://code.visualstudio.com/download) as IDE.
+
 ## Design
 
 You can follow the [design doc](docs/design.md) to learn more about the design details.


### PR DESCRIPTION
Moved Getting Started guide to README.md so users can directly deploy the dashboard without browsing contribution guide.
A reference link has been added in CONTRIBUTING.md to avoid duplication and guide contributors to the correct section.
Fixes: #68