### PR TITLE
filtering enhancement and UI upgrade

### DIFF
--- a/frontend/src/components/jobs/JobTable/JobTable.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTable.jsx
@@ -1,14 +1,74 @@
-import React from "react";
+// Fixed JobTable.jsx with Working Expand/Collapse
+import React, { useState } from "react";
 import {
     TableContainer,
     Table,
+    TableHead,
     TableBody,
+    TableRow,
+    TableCell,
     Paper,
     useTheme,
     alpha,
+    Box,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+    IconButton,
+    Typography,
+    Chip,
+    styled,
+    Collapse,
 } from "@mui/material";
-import JobTableHeader from "./JobTableHeader";
+import { ArrowUpward, ArrowDownward, FilterList, Clear, ExpandMore, ExpandLess } from "@mui/icons-material";
 import JobTableRow from "./JobTableRow";
+
+// Compact styled components
+const CompactFilterContainer = styled(Box)(({ theme }) => ({
+    background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.06)} 0%, ${alpha(theme.palette.secondary.main, 0.06)} 100%)`,
+    backdropFilter: 'blur(8px)',
+    border: `1px solid ${alpha(theme.palette.primary.main, 0.1)}`,
+    borderRadius: '12px',
+    padding: '12px 16px',
+    marginBottom: '16px',
+    boxShadow: `0 4px 16px ${alpha(theme.palette.common.black, 0.06)}`,
+}));
+
+const CompactFormControl = styled(FormControl)(({ theme }) => ({
+    minWidth: 120,
+    '& .MuiOutlinedInput-root': {
+        height: '36px',
+        backgroundColor: alpha(theme.palette.background.paper, 0.8),
+        borderRadius: '8px',
+        fontSize: '14px',
+        transition: 'all 0.2s ease',
+        border: `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+        '&:hover': {
+            borderColor: theme.palette.primary.main,
+            boxShadow: `0 2px 8px ${alpha(theme.palette.primary.main, 0.12)}`,
+        },
+        '&.Mui-focused': {
+            borderColor: theme.palette.primary.main,
+            boxShadow: `0 3px 12px ${alpha(theme.palette.primary.main, 0.2)}`,
+        },
+        '& .MuiOutlinedInput-notchedOutline': {
+            border: 'none',
+        }
+    },
+    '& .MuiInputLabel-root': {
+        fontSize: '13px',
+        fontWeight: 500,
+        transform: 'translate(12px, 9px) scale(1)',
+        '&.MuiInputLabel-shrink': {
+            transform: 'translate(12px, -6px) scale(0.85)',
+        }
+    },
+    '& .MuiSelect-select': {
+        padding: '8px 12px',
+        fontSize: '14px',
+    }
+}));
 
 const JobTable = ({
     jobs,
@@ -17,65 +77,287 @@ const JobTable = ({
     uniqueStatuses,
     allNamespaces,
     allQueues,
-    anchorEl,
-    handleFilterClick,
-    handleFilterClose,
+    onFilterChange,
     sortDirection,
     toggleSortDirection,
 }) => {
     const theme = useTheme();
+    const [showAdvanced, setShowAdvanced] = useState(false);
+    
+    const activeFiltersCount = Object.values(filters).filter(value => value !== "All" && value !== "default").length;
+
+    const clearAllFilters = () => {
+        onFilterChange('namespace', 'default');
+        onFilterChange('queue', 'All');
+        onFilterChange('status', 'All');
+    };
+
+    // FIXED: Toggle function that actually works
+    const toggleAdvanced = () => {
+        setShowAdvanced(!showAdvanced);
+    };
 
     return (
-        <TableContainer
-            component={Paper}
-            sx={{
-                maxHeight: "calc(100vh - 200px)",
-                overflow: "auto",
-                borderRadius: "16px",
-                boxShadow: "0 10px 30px rgba(0, 0, 0, 0.08)",
-                background: `linear-gradient(to bottom, ${alpha(theme.palette.background.paper, 0.9)}, ${theme.palette.background.paper})`,
-                backdropFilter: "blur(10px)",
-                border: `1px solid ${alpha(theme.palette.divider, 0.1)}`,
-                "&::-webkit-scrollbar": {
-                    width: "10px",
-                    height: "10px",
-                },
-                "&::-webkit-scrollbar-thumb": {
-                    backgroundColor: alpha(theme.palette.primary.main, 0.2),
-                    borderRadius: "5px",
-                    "&:hover": {
-                        backgroundColor: alpha(theme.palette.primary.main, 0.3),
+        <Box>
+            {/* Compact Filters Section */}
+            <CompactFilterContainer>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                    {/* Filter Icon and Label */}
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <FilterList sx={{ color: 'primary.main', fontSize: 18 }} />
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'text.primary' }}>
+                            Filters
+                        </Typography>
+                        {activeFiltersCount > 0 && (
+                            <Chip 
+                                label={activeFiltersCount} 
+                                size="small" 
+                                color="primary"
+                                sx={{ height: 20, fontSize: '11px', fontWeight: 600 }}
+                            />
+                        )}
+                    </Box>
+
+                    {/* Main Filters - Always Visible */}
+                    <CompactFormControl size="small">
+                        <InputLabel>Namespace</InputLabel>
+                        <Select
+                            value={filters.namespace}
+                            label="Namespace"
+                            onChange={(e) => onFilterChange('namespace', e.target.value)}
+                        >
+                            {allNamespaces.map(ns => (
+                                <MenuItem key={ns} value={ns}>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <Box sx={{ 
+                                            width: 6, 
+                                            height: 6, 
+                                            borderRadius: '50%', 
+                                            backgroundColor: ns === 'default' ? 'primary.main' : 'secondary.main' 
+                                        }} />
+                                        {ns}
+                                    </Box>
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </CompactFormControl>
+
+                    <CompactFormControl size="small">
+                        <InputLabel>Queue</InputLabel>
+                        <Select
+                            value={filters.queue}
+                            label="Queue"
+                            onChange={(e) => onFilterChange('queue', e.target.value)}
+                        >
+                            {allQueues
+                                .filter((queue, index, arr) => arr.indexOf(queue) === index)
+                                .map(queue => (
+                                    <MenuItem key={queue} value={queue}>
+                                        <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                            <Box sx={{ 
+                                                width: 6, 
+                                                height: 6, 
+                                                borderRadius: '2px', 
+                                                backgroundColor: queue === 'All' ? 'text.secondary' : 'warning.main' 
+                                            }} />
+                                            {queue}
+                                        </Box>
+                                    </MenuItem>
+                                ))}
+                        </Select>
+                    </CompactFormControl>
+
+                    <CompactFormControl size="small">
+                        <InputLabel>Status</InputLabel>
+                        <Select
+                            value={filters.status}
+                            label="Status"
+                            onChange={(e) => onFilterChange('status', e.target.value)}
+                        >
+                            <MenuItem value="All">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'text.secondary' }} />
+                                    All
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Running">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'success.main' }} />
+                                    Running
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Failed">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'error.main' }} />
+                                    Failed
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Succeeded">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'info.main' }} />
+                                    Succeeded
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Pending">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'warning.main' }} />
+                                    Pending
+                                </Box>
+                            </MenuItem>
+                        </Select>
+                    </CompactFormControl>
+
+                    {/* Action Buttons */}
+                    <Box sx={{ display: 'flex', gap: 1, ml: 'auto' }}>
+                        {activeFiltersCount > 0 && (
+                            <IconButton 
+                                onClick={clearAllFilters}
+                                size="small"
+                                sx={{ 
+                                    color: 'text.secondary',
+                                    width: 32,
+                                    height: 32,
+                                    '&:hover': { 
+                                        color: 'error.main',
+                                        backgroundColor: alpha(theme.palette.error.main, 0.1)
+                                    }
+                                }}
+                            >
+                                <Clear fontSize="small" />
+                            </IconButton>
+                        )}
+                        
+                        {/* FIXED: Only show expand button if there are active filters */}
+                        {activeFiltersCount > 0 && (
+                            <IconButton 
+                                onClick={toggleAdvanced}
+                                size="small"
+                                sx={{ 
+                                    color: 'primary.main',
+                                    width: 32,
+                                    height: 32,
+                                    '&:hover': { 
+                                        backgroundColor: alpha(theme.palette.primary.main, 0.1)
+                                    }
+                                }}
+                            >
+                                {showAdvanced ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+                            </IconButton>
+                        )}
+                    </Box>
+                </Box>
+
+                {/* FIXED: Collapsible Active Filters Summary - Only controlled by showAdvanced */}
+                <Collapse in={showAdvanced && activeFiltersCount > 0}>
+                    <Box sx={{ mt: 2, pt: 2, borderTop: `1px solid ${alpha(theme.palette.divider, 0.1)}` }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                            Active Filters:
+                        </Typography>
+                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                            {filters.namespace !== 'default' && (
+                                <Chip 
+                                    label={`Namespace: ${filters.namespace}`} 
+                                    size="small"
+                                    onDelete={() => onFilterChange('namespace', 'default')}
+                                    sx={{ height: 24, fontSize: '12px' }}
+                                />
+                            )}
+                            {filters.queue !== 'All' && (
+                                <Chip 
+                                    label={`Queue: ${filters.queue}`} 
+                                    size="small"
+                                    onDelete={() => onFilterChange('queue', 'All')}
+                                    sx={{ height: 24, fontSize: '12px' }}
+                                />
+                            )}
+                            {filters.status !== 'All' && (
+                                <Chip 
+                                    label={`Status: ${filters.status}`} 
+                                    size="small"
+                                    onDelete={() => onFilterChange('status', 'All')}
+                                    sx={{ height: 24, fontSize: '12px' }}
+                                />
+                            )}
+                        </Box>
+                    </Box>
+                </Collapse>
+            </CompactFilterContainer>
+
+            {/* Table with adjusted height */}
+            <TableContainer
+                component={Paper}
+                sx={{
+                    maxHeight: "calc(100vh - 240px)",
+                    overflow: "auto",
+                    borderRadius: "16px",
+                    boxShadow: "0 8px 32px rgba(0, 0, 0, 0.08)",
+                    background: `linear-gradient(to bottom, ${alpha(theme.palette.background.paper, 0.95)}, ${theme.palette.background.paper})`,
+                    backdropFilter: "blur(10px)",
+                    border: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
+                    "&::-webkit-scrollbar": {
+                        width: "6px",
+                        height: "6px",
                     },
-                },
-                "&::-webkit-scrollbar-track": {
-                    backgroundColor: alpha(theme.palette.primary.main, 0.05),
-                    borderRadius: "5px",
-                },
-            }}
-        >
-            <Table stickyHeader>
-                <JobTableHeader
-                    filters={filters}
-                    uniqueStatuses={uniqueStatuses}
-                    allNamespaces={allNamespaces}
-                    allQueues={allQueues}
-                    anchorEl={anchorEl}
-                    handleFilterClick={handleFilterClick}
-                    handleFilterClose={handleFilterClose}
-                    sortDirection={sortDirection}
-                    toggleSortDirection={toggleSortDirection}
-                />
-                <TableBody>
-                    {jobs.map((job) => (
-                        <JobTableRow
-                            key={`${job.metadata.namespace}-${job.metadata.name}`}
-                            job={job}
-                            handleJobClick={handleJobClick}
-                        />
-                    ))}
-                </TableBody>
-            </Table>
-        </TableContainer>
+                    "&::-webkit-scrollbar-thumb": {
+                        backgroundColor: alpha(theme.palette.primary.main, 0.3),
+                        borderRadius: "3px",
+                        "&:hover": {
+                            backgroundColor: alpha(theme.palette.primary.main, 0.5),
+                        },
+                    },
+                }}
+            >
+                <Table stickyHeader>
+                    <TableHead>
+                        <TableRow sx={{
+                            '& .MuiTableCell-head': {
+                                background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.08)} 0%, ${alpha(theme.palette.secondary.main, 0.08)} 100%)`,
+                                backdropFilter: 'blur(8px)',
+                                borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+                                color: theme.palette.text.primary,
+                                fontWeight: 600,
+                                fontSize: '13px',
+                                height: '48px'
+                            }
+                        }}>
+                            <TableCell>Name</TableCell>
+                            <TableCell>Namespace</TableCell>
+                            <TableCell>Queue</TableCell>
+                            <TableCell>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    Creation Time
+                                    <IconButton 
+                                        size="small" 
+                                        onClick={toggleSortDirection}
+                                        sx={{
+                                            color: 'primary.main',
+                                            width: 24,
+                                            height: 24,
+                                            '&:hover': {
+                                                backgroundColor: alpha(theme.palette.primary.main, 0.1)
+                                            }
+                                        }}
+                                    >
+                                        {sortDirection === 'asc' ? <ArrowUpward fontSize="small" /> : <ArrowDownward fontSize="small" />}
+                                    </IconButton>
+                                </Box>
+                            </TableCell>
+                            <TableCell>Status</TableCell>
+                            <TableCell>Actions</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {jobs.map((job) => (
+                            <JobTableRow
+                                key={`${job.metadata.namespace}-${job.metadata.name}`}
+                                job={job}
+                                handleJobClick={handleJobClick}
+                            />
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        </Box>
     );
 };
 

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -154,7 +154,7 @@ const Pods = () => {
                     handleClearSearch={handleClearSearch}
                     handleRefresh={handleRefresh}
                     fetchData={fetchPods}
-                    isRefreshing={false} // Update if needed
+                    isRefreshing={false}
                     placeholder="Search Pods..."
                     refreshLabel="Refresh Pods"
                 />
@@ -165,7 +165,7 @@ const Pods = () => {
                 allNamespaces={allNamespaces}
                 sortDirection={sortDirection}
                 onSortDirectionToggle={toggleSortDirection}
-                onFilterChange={handleFilterChange}
+                onFilterChange={handleFilterChange}  // Updated prop name
                 onPodClick={handlePodClick}
             />
             <PodsPagination

--- a/frontend/src/components/pods/PodsTable/PodsTable.jsx
+++ b/frontend/src/components/pods/PodsTable/PodsTable.jsx
@@ -1,14 +1,74 @@
-import React from "react";
+// Fixed PodsTable.jsx with Working Expand/Collapse
+import React, { useState } from "react";
 import {
     TableContainer,
     Table,
+    TableHead,
     TableBody,
+    TableRow,
+    TableCell,
     Paper,
     useTheme,
     alpha,
+    Box,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+    IconButton,
+    Typography,
+    Chip,
+    styled,
+    Collapse,
 } from "@mui/material";
-import TableHeader from "./TableHeader";
+import { ArrowUpward, ArrowDownward, FilterList, Clear, ExpandMore, ExpandLess } from "@mui/icons-material";
 import PodRow from "./PodRow";
+
+// Compact styled components
+const CompactFilterContainer = styled(Box)(({ theme }) => ({
+    background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.06)} 0%, ${alpha(theme.palette.secondary.main, 0.06)} 100%)`,
+    backdropFilter: 'blur(8px)',
+    border: `1px solid ${alpha(theme.palette.primary.main, 0.1)}`,
+    borderRadius: '12px',
+    padding: '12px 16px',
+    marginBottom: '16px',
+    boxShadow: `0 4px 16px ${alpha(theme.palette.common.black, 0.06)}`,
+}));
+
+const CompactFormControl = styled(FormControl)(({ theme }) => ({
+    minWidth: 120,
+    '& .MuiOutlinedInput-root': {
+        height: '36px',
+        backgroundColor: alpha(theme.palette.background.paper, 0.8),
+        borderRadius: '8px',
+        fontSize: '14px',
+        transition: 'all 0.2s ease',
+        border: `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+        '&:hover': {
+            borderColor: theme.palette.primary.main,
+            boxShadow: `0 2px 8px ${alpha(theme.palette.primary.main, 0.12)}`,
+        },
+        '&.Mui-focused': {
+            borderColor: theme.palette.primary.main,
+            boxShadow: `0 3px 12px ${alpha(theme.palette.primary.main, 0.2)}`,
+        },
+        '& .MuiOutlinedInput-notchedOutline': {
+            border: 'none',
+        }
+    },
+    '& .MuiInputLabel-root': {
+        fontSize: '13px',
+        fontWeight: 500,
+        transform: 'translate(12px, 9px) scale(1)',
+        '&.MuiInputLabel-shrink': {
+            transform: 'translate(12px, -6px) scale(0.85)',
+        }
+    },
+    '& .MuiSelect-select': {
+        padding: '8px 12px',
+        fontSize: '14px',
+    }
+}));
 
 const PodsTable = ({
     pods,
@@ -20,22 +80,7 @@ const PodsTable = ({
     onPodClick,
 }) => {
     const theme = useTheme();
-    const [anchorEl, setAnchorEl] = React.useState({
-        status: null,
-        namespace: null,
-    });
-
-    const handleFilterClick = React.useCallback((filterType, event) => {
-        setAnchorEl((prev) => ({ ...prev, [filterType]: event.currentTarget }));
-    }, []);
-
-    const handleFilterClose = React.useCallback(
-        (filterType, value) => {
-            onFilterChange(filterType, value);
-            setAnchorEl((prev) => ({ ...prev, [filterType]: null }));
-        },
-        [onFilterChange],
-    );
+    const [showAdvanced, setShowAdvanced] = useState(false);
 
     const filteredPods = React.useMemo(
         () =>
@@ -81,56 +126,246 @@ const PodsTable = ({
         [theme],
     );
 
+    const activeFiltersCount = Object.values(filters).filter(value => value !== "All" && value !== "default").length;
+
+    const clearAllFilters = () => {
+        onFilterChange('namespace', 'default');
+        onFilterChange('status', 'All');
+    };
+
+    // FIXED: Toggle function that actually works
+    const toggleAdvanced = () => {
+        setShowAdvanced(!showAdvanced);
+    };
+
     return (
-        <TableContainer
-            component={Paper}
-            sx={{
-                maxHeight: "calc(100vh - 200px)",
-                overflow: "auto",
-                borderRadius: "16px",
-                boxShadow: "0 10px 30px rgba(0, 0, 0, 0.08)",
-                background: `linear-gradient(to bottom, ${alpha(theme.palette.background.paper, 0.9)}, ${theme.palette.background.paper})`,
-                backdropFilter: "blur(10px)",
-                border: `1px solid ${alpha(theme.palette.divider, 0.1)}`,
-                "&::-webkit-scrollbar": {
-                    width: "10px",
-                    height: "10px",
-                },
-                "&::-webkit-scrollbar-thumb": {
-                    backgroundColor: alpha(theme.palette.primary.main, 0.2),
-                    borderRadius: "5px",
-                    "&:hover": {
-                        backgroundColor: alpha(theme.palette.primary.main, 0.3),
+        <Box>
+            {/* Compact Filters Section */}
+            <CompactFilterContainer>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                    {/* Filter Icon and Label */}
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <FilterList sx={{ color: 'primary.main', fontSize: 18 }} />
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'text.primary' }}>
+                            Filters
+                        </Typography>
+                        {activeFiltersCount > 0 && (
+                            <Chip 
+                                label={activeFiltersCount} 
+                                size="small" 
+                                color="primary"
+                                sx={{ height: 20, fontSize: '11px', fontWeight: 600 }}
+                            />
+                        )}
+                    </Box>
+
+                    {/* Main Filters - Always Visible */}
+                    <CompactFormControl size="small">
+                        <InputLabel>Namespace</InputLabel>
+                        <Select
+                            value={filters.namespace}
+                            label="Namespace"
+                            onChange={(e) => onFilterChange('namespace', e.target.value)}
+                        >
+                            {allNamespaces.map(ns => (
+                                <MenuItem key={ns} value={ns}>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <Box sx={{ 
+                                            width: 6, 
+                                            height: 6, 
+                                            borderRadius: '50%', 
+                                            backgroundColor: ns === 'default' ? 'primary.main' : 'secondary.main' 
+                                        }} />
+                                        {ns}
+                                    </Box>
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </CompactFormControl>
+
+                    <CompactFormControl size="small">
+                        <InputLabel>Status</InputLabel>
+                        <Select
+                            value={filters.status}
+                            label="Status"
+                            onChange={(e) => onFilterChange('status', e.target.value)}
+                        >
+                            <MenuItem value="All">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'text.secondary' }} />
+                                    All
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Running">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'success.main' }} />
+                                    Running
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Failed">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'error.main' }} />
+                                    Failed
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Pending">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'warning.main' }} />
+                                    Pending
+                                </Box>
+                            </MenuItem>
+                            <MenuItem value="Succeeded">
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    <Box sx={{ width: 6, height: 6, borderRadius: '50%', backgroundColor: 'info.main' }} />
+                                    Succeeded
+                                </Box>
+                            </MenuItem>
+                        </Select>
+                    </CompactFormControl>
+
+                    {/* Action Buttons */}
+                    <Box sx={{ display: 'flex', gap: 1, ml: 'auto' }}>
+                        {activeFiltersCount > 0 && (
+                            <IconButton 
+                                onClick={clearAllFilters}
+                                size="small"
+                                sx={{ 
+                                    color: 'text.secondary',
+                                    width: 32,
+                                    height: 32,
+                                    '&:hover': { 
+                                        color: 'error.main',
+                                        backgroundColor: alpha(theme.palette.error.main, 0.1)
+                                    }
+                                }}
+                            >
+                                <Clear fontSize="small" />
+                            </IconButton>
+                        )}
+                        
+                        {/* FIXED: Only show expand button if there are active filters */}
+                        {activeFiltersCount > 0 && (
+                            <IconButton 
+                                onClick={toggleAdvanced}
+                                size="small"
+                                sx={{ 
+                                    color: 'primary.main',
+                                    width: 32,
+                                    height: 32,
+                                    '&:hover': { 
+                                        backgroundColor: alpha(theme.palette.primary.main, 0.1)
+                                    }
+                                }}
+                            >
+                                {showAdvanced ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+                            </IconButton>
+                        )}
+                    </Box>
+                </Box>
+
+                {/* FIXED: Collapsible Active Filters Summary - Only controlled by showAdvanced */}
+                <Collapse in={showAdvanced && activeFiltersCount > 0}>
+                    <Box sx={{ mt: 2, pt: 2, borderTop: `1px solid ${alpha(theme.palette.divider, 0.1)}` }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                            Active Filters:
+                        </Typography>
+                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                            {filters.namespace !== 'default' && (
+                                <Chip 
+                                    label={`Namespace: ${filters.namespace}`} 
+                                    size="small"
+                                    onDelete={() => onFilterChange('namespace', 'default')}
+                                    sx={{ height: 24, fontSize: '12px' }}
+                                />
+                            )}
+                            {filters.status !== 'All' && (
+                                <Chip 
+                                    label={`Status: ${filters.status}`} 
+                                    size="small"
+                                    onDelete={() => onFilterChange('status', 'All')}
+                                    sx={{ height: 24, fontSize: '12px' }}
+                                />
+                            )}
+                        </Box>
+                    </Box>
+                </Collapse>
+            </CompactFilterContainer>
+
+            {/* Table with adjusted height */}
+            <TableContainer
+                component={Paper}
+                sx={{
+                    maxHeight: "calc(100vh - 240px)",
+                    overflow: "auto",
+                    borderRadius: "16px",
+                    boxShadow: "0 8px 32px rgba(0, 0, 0, 0.08)",
+                    background: `linear-gradient(to bottom, ${alpha(theme.palette.background.paper, 0.95)}, ${theme.palette.background.paper})`,
+                    backdropFilter: "blur(10px)",
+                    border: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
+                    "&::-webkit-scrollbar": {
+                        width: "6px",
+                        height: "6px",
                     },
-                },
-                "&::-webkit-scrollbar-track": {
-                    backgroundColor: alpha(theme.palette.primary.main, 0.05),
-                    borderRadius: "5px",
-                },
-            }}
-        >
-            <Table stickyHeader>
-                <TableHeader
-                    filters={filters}
-                    anchorEl={anchorEl}
-                    handleFilterClick={handleFilterClick}
-                    handleFilterClose={handleFilterClose}
-                    allNamespaces={allNamespaces}
-                    onSortDirectionToggle={onSortDirectionToggle}
-                    sortDirection={sortDirection}
-                />
-                <TableBody>
-                    {sortedPods.map((pod) => (
-                        <PodRow
-                            key={`${pod.metadata.namespace}-${pod.metadata.name}`}
-                            pod={pod}
-                            getStatusColor={getStatusColor}
-                            onPodClick={onPodClick}
-                        />
-                    ))}
-                </TableBody>
-            </Table>
-        </TableContainer>
+                    "&::-webkit-scrollbar-thumb": {
+                        backgroundColor: alpha(theme.palette.primary.main, 0.3),
+                        borderRadius: "3px",
+                        "&:hover": {
+                            backgroundColor: alpha(theme.palette.primary.main, 0.5),
+                        },
+                    },
+                }}
+            >
+                <Table stickyHeader>
+                    <TableHead>
+                        <TableRow sx={{
+                            '& .MuiTableCell-head': {
+                                background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.08)} 0%, ${alpha(theme.palette.secondary.main, 0.08)} 100%)`,
+                                backdropFilter: 'blur(8px)',
+                                borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+                                color: theme.palette.text.primary,
+                                fontWeight: 600,
+                                fontSize: '13px',
+                                height: '48px'
+                            }
+                        }}>
+                            <TableCell>Name</TableCell>
+                            <TableCell>Namespace</TableCell>
+                            <TableCell>
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    Creation Time
+                                    <IconButton 
+                                        size="small" 
+                                        onClick={onSortDirectionToggle}
+                                        sx={{
+                                            color: 'primary.main',
+                                            width: 24,
+                                            height: 24,
+                                            '&:hover': {
+                                                backgroundColor: alpha(theme.palette.primary.main, 0.1)
+                                            }
+                                        }}
+                                    >
+                                        {sortDirection === 'asc' ? <ArrowUpward fontSize="small" /> : <ArrowDownward fontSize="small" />}
+                                    </IconButton>
+                                </Box>
+                            </TableCell>
+                            <TableCell>Status</TableCell>
+                            <TableCell>Age</TableCell>
+                        </TableRow>
+                    </TableHead>
+                    <TableBody>
+                        {sortedPods.map((pod) => (
+                            <PodRow
+                                key={`${pod.metadata.namespace}-${pod.metadata.name}`}
+                                pod={pod}
+                                getStatusColor={getStatusColor}
+                                onPodClick={onPodClick}
+                            />
+                        ))}
+                    </TableBody>
+                </Table>
+            </TableContainer>
+        </Box>
     );
 };
 

--- a/frontend/src/components/queues/QueueTable/QueueTable.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTable.jsx
@@ -1,15 +1,75 @@
+// Fixed QueueTable.jsx with Working Expand/Collapse
 import React, { useState } from "react";
 import {
     TableContainer,
     Table,
+    TableHead,
     TableBody,
+    TableRow,
+    TableCell,
     Paper,
     useTheme,
     alpha,
+    Box,
+    FormControl,
+    InputLabel,
+    Select,
+    MenuItem,
+    IconButton,
+    Typography,
+    Chip,
+    styled,
+    Collapse,
 } from "@mui/material";
-import QueueTableHeader from "./QueueTableHeader";
+import { ArrowUpward, ArrowDownward, FilterList, Clear, ExpandMore, ExpandLess } from "@mui/icons-material";
 import QueueTableRow from "./QueueTableRow";
 import QueueTableDeleteDialog from "./QueueTableDeleteDialog";
+
+// Compact styled components
+const CompactFilterContainer = styled(Box)(({ theme }) => ({
+    background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.06)} 0%, ${alpha(theme.palette.secondary.main, 0.06)} 100%)`,
+    backdropFilter: 'blur(8px)',
+    border: `1px solid ${alpha(theme.palette.primary.main, 0.1)}`,
+    borderRadius: '12px',
+    padding: '12px 16px',
+    marginBottom: '16px',
+    boxShadow: `0 4px 16px ${alpha(theme.palette.common.black, 0.06)}`,
+}));
+
+const CompactFormControl = styled(FormControl)(({ theme }) => ({
+    minWidth: 120,
+    '& .MuiOutlinedInput-root': {
+        height: '36px',
+        backgroundColor: alpha(theme.palette.background.paper, 0.8),
+        borderRadius: '8px',
+        fontSize: '14px',
+        transition: 'all 0.2s ease',
+        border: `1px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+        '&:hover': {
+            borderColor: theme.palette.primary.main,
+            boxShadow: `0 2px 8px ${alpha(theme.palette.primary.main, 0.12)}`,
+        },
+        '&.Mui-focused': {
+            borderColor: theme.palette.primary.main,
+            boxShadow: `0 3px 12px ${alpha(theme.palette.primary.main, 0.2)}`,
+        },
+        '& .MuiOutlinedInput-notchedOutline': {
+            border: 'none',
+        }
+    },
+    '& .MuiInputLabel-root': {
+        fontSize: '13px',
+        fontWeight: 500,
+        transform: 'translate(12px, 9px) scale(1)',
+        '&.MuiInputLabel-shrink': {
+            transform: 'translate(12px, -6px) scale(0.85)',
+        }
+    },
+    '& .MuiSelect-select': {
+        padding: '8px 12px',
+        fontSize: '14px',
+    }
+}));
 
 const QueueTable = ({
     sortedQueues,
@@ -18,16 +78,14 @@ const QueueTable = ({
     handleSort,
     sortConfig,
     filters,
-    handleFilterClick,
-    anchorEl,
     uniqueStates,
-    handleFilterClose,
-    setAnchorEl,
+    onFilterChange,
     handleDelete,
 }) => {
     const theme = useTheme();
     const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
     const [queueToDelete, setQueueToDelete] = useState(null);
+    const [showAdvanced, setShowAdvanced] = useState(false);
 
     const handleOpenDeleteDialog = (queueName) => {
         setQueueToDelete(queueName);
@@ -46,53 +104,218 @@ const QueueTable = ({
         handleCloseDeleteDialog();
     };
 
+    const activeFiltersCount = Object.values(filters).filter(value => value !== "All").length;
+
+    const clearAllFilters = () => {
+        onFilterChange('status', 'All');
+    };
+
+    // FIXED: Toggle function that actually works
+    const toggleAdvanced = () => {
+        setShowAdvanced(!showAdvanced);
+    };
+
     return (
-        <React.Fragment>
+        <Box>
+            {/* Compact Filters Section */}
+            <CompactFilterContainer>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 2, flexWrap: 'wrap' }}>
+                    {/* Filter Icon and Label */}
+                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                        <FilterList sx={{ color: 'primary.main', fontSize: 18 }} />
+                        <Typography variant="subtitle2" sx={{ fontWeight: 600, color: 'text.primary' }}>
+                            Filters
+                        </Typography>
+                        {activeFiltersCount > 0 && (
+                            <Chip 
+                                label={activeFiltersCount} 
+                                size="small" 
+                                color="primary"
+                                sx={{ height: 20, fontSize: '11px', fontWeight: 600 }}
+                            />
+                        )}
+                    </Box>
+
+                    {/* Main Filters - Always Visible */}
+                    <CompactFormControl size="small">
+                        <InputLabel>State</InputLabel>
+                        <Select
+                            value={filters.status}
+                            label="State"
+                            onChange={(e) => onFilterChange('status', e.target.value)}
+                        >
+                            {uniqueStates.map(state => (
+                                <MenuItem key={state} value={state}>
+                                    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                        <Box sx={{ 
+                                            width: 6, 
+                                            height: 6, 
+                                            borderRadius: state === 'Open' ? '50%' : '2px', 
+                                            backgroundColor: state === 'All' ? 'text.secondary' : 
+                                                           state === 'Open' ? 'success.main' : 
+                                                           state === 'Closed' ? 'error.main' : 'warning.main'
+                                        }} />
+                                        {state}
+                                    </Box>
+                                </MenuItem>
+                            ))}
+                        </Select>
+                    </CompactFormControl>
+
+                    {/* Action Buttons */}
+                    <Box sx={{ display: 'flex', gap: 1, ml: 'auto' }}>
+                        {activeFiltersCount > 0 && (
+                            <IconButton 
+                                onClick={clearAllFilters}
+                                size="small"
+                                sx={{ 
+                                    color: 'text.secondary',
+                                    width: 32,
+                                    height: 32,
+                                    '&:hover': { 
+                                        color: 'error.main',
+                                        backgroundColor: alpha(theme.palette.error.main, 0.1)
+                                    }
+                                }}
+                            >
+                                <Clear fontSize="small" />
+                            </IconButton>
+                        )}
+                        
+                        {/* FIXED: Only show expand button if there are active filters */}
+                        {activeFiltersCount > 0 && (
+                            <IconButton 
+                                onClick={toggleAdvanced}
+                                size="small"
+                                sx={{ 
+                                    color: 'primary.main',
+                                    width: 32,
+                                    height: 32,
+                                    '&:hover': { 
+                                        backgroundColor: alpha(theme.palette.primary.main, 0.1)
+                                    }
+                                }}
+                            >
+                                {showAdvanced ? <ExpandLess fontSize="small" /> : <ExpandMore fontSize="small" />}
+                            </IconButton>
+                        )}
+                    </Box>
+                </Box>
+
+                {/* FIXED: Collapsible Active Filters Summary - Only controlled by showAdvanced */}
+                <Collapse in={showAdvanced && activeFiltersCount > 0}>
+                    <Box sx={{ mt: 2, pt: 2, borderTop: `1px solid ${alpha(theme.palette.divider, 0.1)}` }}>
+                        <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: 'block' }}>
+                            Active Filters:
+                        </Typography>
+                        <Box sx={{ display: 'flex', gap: 1, flexWrap: 'wrap' }}>
+                            {filters.status !== 'All' && (
+                                <Chip 
+                                    label={`State: ${filters.status}`} 
+                                    size="small"
+                                    onDelete={() => onFilterChange('status', 'All')}
+                                    sx={{ height: 24, fontSize: '12px' }}
+                                />
+                            )}
+                        </Box>
+                    </Box>
+                </Collapse>
+            </CompactFilterContainer>
+
+            {/* Table with adjusted height */}
             <TableContainer
                 component={Paper}
                 sx={{
-                    maxHeight: "calc(100vh - 200px)",
+                    maxHeight: "calc(100vh - 240px)",
                     overflow: "auto",
                     borderRadius: "16px",
-                    boxShadow: "0 10px 30px rgba(0, 0, 0, 0.08)",
-                    background: `linear-gradient(to bottom, ${alpha(theme.palette.background.paper, 0.9)}, ${theme.palette.background.paper})`,
+                    boxShadow: "0 8px 32px rgba(0, 0, 0, 0.08)",
+                    background: `linear-gradient(to bottom, ${alpha(theme.palette.background.paper, 0.95)}, ${theme.palette.background.paper})`,
                     backdropFilter: "blur(10px)",
-                    border: `1px solid ${alpha(theme.palette.divider, 0.1)}`,
+                    border: `1px solid ${alpha(theme.palette.divider, 0.08)}`,
                     "&::-webkit-scrollbar": {
-                        width: "10px",
-                        height: "10px",
+                        width: "6px",
+                        height: "6px",
                     },
                     "&::-webkit-scrollbar-thumb": {
-                        backgroundColor: alpha(theme.palette.primary.main, 0.2),
-                        borderRadius: "5px",
+                        backgroundColor: alpha(theme.palette.primary.main, 0.3),
+                        borderRadius: "3px",
                         "&:hover": {
-                            backgroundColor: alpha(
-                                theme.palette.primary.main,
-                                0.3,
-                            ),
+                            backgroundColor: alpha(theme.palette.primary.main, 0.5),
                         },
-                    },
-                    "&::-webkit-scrollbar-track": {
-                        backgroundColor: alpha(
-                            theme.palette.primary.main,
-                            0.05,
-                        ),
-                        borderRadius: "5px",
                     },
                 }}
             >
                 <Table stickyHeader>
-                    <QueueTableHeader
-                        allocatedFields={allocatedFields}
-                        handleSort={handleSort}
-                        sortConfig={sortConfig}
-                        filters={filters}
-                        handleFilterClick={handleFilterClick}
-                        anchorEl={anchorEl}
-                        uniqueStates={uniqueStates}
-                        handleFilterClose={handleFilterClose}
-                        setAnchorEl={setAnchorEl}
-                    />
+                    <TableHead>
+                        <TableRow sx={{
+                            '& .MuiTableCell-head': {
+                                background: `linear-gradient(135deg, ${alpha(theme.palette.primary.main, 0.08)} 0%, ${alpha(theme.palette.secondary.main, 0.08)} 100%)`,
+                                backdropFilter: 'blur(8px)',
+                                borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.15)}`,
+                                color: theme.palette.text.primary,
+                                fontWeight: 600,
+                                fontSize: '13px',
+                                height: '48px'
+                            }
+                        }}>
+                            <TableCell>Name</TableCell>
+                            <TableCell 
+                                sx={{ cursor: 'pointer' }}
+                                onClick={() => handleSort('cpu')}
+                            >
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    Allocated CPU
+                                    {sortConfig.field === 'cpu' && (
+                                        sortConfig.direction === 'asc' ? 
+                                        <ArrowUpward fontSize="small" /> : 
+                                        <ArrowDownward fontSize="small" />
+                                    )}
+                                </Box>
+                            </TableCell>
+                            <TableCell 
+                                sx={{ cursor: 'pointer' }}
+                                onClick={() => handleSort('memory')}
+                            >
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    Allocated Memory
+                                    {sortConfig.field === 'memory' && (
+                                        sortConfig.direction === 'asc' ? 
+                                        <ArrowUpward fontSize="small" /> : 
+                                        <ArrowDownward fontSize="small" />
+                                    )}
+                                </Box>
+                            </TableCell>
+                            <TableCell 
+                                sx={{ cursor: 'pointer' }}
+                                onClick={() => handleSort('pods')}
+                            >
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    Allocated Pods
+                                    {sortConfig.field === 'pods' && (
+                                        sortConfig.direction === 'asc' ? 
+                                        <ArrowUpward fontSize="small" /> : 
+                                        <ArrowDownward fontSize="small" />
+                                    )}
+                                </Box>
+                            </TableCell>
+                            <TableCell 
+                                sx={{ cursor: 'pointer' }}
+                                onClick={() => handleSort('creationTime')}
+                            >
+                                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                                    Creation Time
+                                    {sortConfig.field === 'creationTime' && (
+                                        sortConfig.direction === 'asc' ? 
+                                        <ArrowUpward fontSize="small" /> : 
+                                        <ArrowDownward fontSize="small" />
+                                    )}
+                                </Box>
+                            </TableCell>
+                            <TableCell>State</TableCell>
+                            <TableCell>Actions</TableCell>
+                        </TableRow>
+                    </TableHead>
                     <TableBody>
                         {sortedQueues.map((queue) => (
                             <QueueTableRow
@@ -106,13 +329,14 @@ const QueueTable = ({
                     </TableBody>
                 </Table>
             </TableContainer>
+
             <QueueTableDeleteDialog
                 open={openDeleteDialog}
                 onClose={handleCloseDeleteDialog}
                 onConfirm={confirmDelete}
                 queueToDelete={queueToDelete}
             />
-        </React.Fragment>
+        </Box>
     );
 };
 

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import axios from "axios";
-import { parseCPU, parseMemoryToMi } from "../utils"; // Adjust this path based on your project structure
+import { parseCPU, parseMemoryToMi } from "../utils";
 import SearchBar from "../Searchbar";
 import QueueTable from "./QueueTable/QueueTable";
 import QueuePagination from "./QueuePagination";
@@ -17,9 +17,6 @@ const Queues = () => {
     });
     const [selectedQueueYaml, setSelectedQueueYaml] = useState("");
     const [openDialog, setOpenDialog] = useState(false);
-    const [anchorEl, setAnchorEl] = useState({
-        status: null,
-    });
     const [searchText, setSearchText] = useState("");
     const [selectedQueueName, setSelectedQueueName] = useState("");
     const [pagination, setPagination] = useState({
@@ -130,13 +127,9 @@ const Queues = () => {
         }));
     }, []);
 
-    const handleFilterClick = useCallback((filterType, event) => {
-        setAnchorEl((prev) => ({ ...prev, [filterType]: event.currentTarget }));
-    }, []);
-
-    const handleFilterClose = useCallback((filterType, value) => {
+    // ADD THIS FUNCTION - replaces the old handleFilterClick/handleFilterClose pattern
+    const handleFilterChange = useCallback((filterType, value) => {
         setFilters((prev) => ({ ...prev, [filterType]: value }));
-        setAnchorEl((prev) => ({ ...prev, [filterType]: null }));
         setPagination((prev) => ({ ...prev, page: 1 }));
     }, []);
 
@@ -225,7 +218,7 @@ const Queues = () => {
                     handleClearSearch={handleClearSearch}
                     handleRefresh={handleRefresh}
                     fetchData={fetchQueues}
-                    isRefreshing={false} // Update if needed
+                    isRefreshing={false}
                     placeholder="Search queues..."
                     refreshLabel="Refresh Queues"
                 />
@@ -237,11 +230,8 @@ const Queues = () => {
                 handleSort={handleSort}
                 sortConfig={sortConfig}
                 filters={filters}
-                handleFilterClick={handleFilterClick}
-                anchorEl={anchorEl}
                 uniqueStates={uniqueStates}
-                handleFilterClose={handleFilterClose}
-                setAnchorEl={setAnchorEl}
+                onFilterChange={handleFilterChange}  // Updated prop name
             />
             <QueuePagination
                 pagination={pagination}


### PR DESCRIPTION
### Overview
This PR completely transforms the table filter experience across the Volcano Dashboard by replacing scattered, header-embedded filters with a modern, compact, and visually stunning filter interface.

### Solves #140

Before:

❌ Filter dropdowns embedded in table headers causing multi-line wrapping
❌ Inconsistent header heights across different tables
❌ Plain, unstyled filter controls
❌ Poor visual hierarchy and cluttered appearance

After:

✅ Clean, single-line table headers
✅ Compact filter row above each table
✅ Beautiful glassmorphism design with gradients
✅ Consistent visual experience across all tables
✅ Fixed filter logic issues
✅ Professional dashboard appearance

### Key Features

Modern Visual Design

- Glassmorphism effects with blur backgrounds and gradients
- Color-coded indicators for namespaces, queues, and statuses
- Smooth hover animations and focus states
- Compact form controls optimized for space efficiency

Smart Filter Management

- Active filter counter showing applied filters at a glance
- One-click clear all functionality with animated feedback
- Collapsible advanced view for filter details
- Individual filter removal via deletable chips

Enhanced User Experience

- Visual status indicators (green dots for Running, red for Failed, etc.)
- Namespace differentiation with colored dots
- Responsive layout that adapts to screen size
- Consistent behavior across Pods, Jobs, and Queues tables

<img width="1114" alt="Screenshot 2025-05-22 at 11 58 49 PM" src="https://github.com/user-attachments/assets/2b5240cb-004a-4176-b7c4-c1d369dfcb33" />
<img width="1114" alt="Screenshot 2025-05-22 at 11 59 00 PM" src="https://github.com/user-attachments/assets/a99f407d-cc09-4d09-a8c4-f48c10699654" />
<img width="1114" alt="Screenshot 2025-05-22 at 11 59 21 PM" src="https://github.com/user-attachments/assets/fa03ed52-26e6-4e65-8a30-9bef3dd4be56" />
<img width="1114" alt="Screenshot 2025-05-22 at 11 59 34 PM" src="https://github.com/user-attachments/assets/28771e48-bed7-45c5-97ff-addde85a8ec3" />