### PR TITLE
feat: show real-time cpu-memory metrics

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -4,6 +4,9 @@ import {
     CoreV1Api,
     CustomObjectsApi,
     KubeConfig,
+    Metrics,
+    topPods,
+    topNodes,
 } from "@kubernetes/client-node";
 import yaml from "js-yaml";
 
@@ -15,6 +18,53 @@ kc.loadFromDefault();
 
 const k8sApi = kc.makeApiClient(CustomObjectsApi);
 const k8sCoreApi = kc.makeApiClient(CoreV1Api);
+
+const metricsClient = new Metrics(kc);
+
+const getPodMetrics = async () => {
+    const pods = await topPods(k8sCoreApi, metricsClient, "default");
+    return pods.map((pod) => {
+        return {
+            name: pod.Pod.metadata?.name,
+            cpu: pod.CPU.CurrentUsage,
+            memory: pod.Memory.CurrentUsage,
+        };
+    });
+};
+
+const getNodeMetrics = async () => {
+    const nodes = await topNodes(k8sCoreApi);
+    return nodes.map((node) => ({ cpu: node.CPU, memory: node.Memory }));
+};
+
+app.get("/api/metrics", async (req, res) => {
+    try {
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.setHeader("Connection", "keep-alive");
+
+        const intervalId = setInterval(async () => {
+            try {
+                const nodeMetrics = await getNodeMetrics();
+                const podMetrics = await getPodMetrics();
+                res.write(
+                    `data: ${JSON.stringify({ podMetrics, nodeMetrics }, (_, v) => (typeof v === "bigint" ? v.toString() : v))}\n\n`,
+                );
+            } catch (err) {
+                throw new Error("Error fetching metrics");
+            }
+        }, 1000);
+
+        req.on("close", () => {
+            console.log("Client disconnected.");
+            clearInterval(intervalId);
+            res.end();
+        });
+    } catch (err) {
+        console.log("Error fetching metrics:", err);
+        res.status(500).send("Internal server error");
+    }
+});
 
 app.get("/api/jobs", async (req, res) => {
     try {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
         "@mui/material": "^6.4.4",
         "axios": "^1.7.9",
         "bootstrap": "^5.3.5",
-        "chart.js": "^4.4.7",
+        "chart.js": "^4.4.9",
         "dotenv": "^16.4.7",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -5,6 +5,7 @@ import DashboardHeader from "./DashboardHeader";
 import StatCardsContainer from "./StatCardsContainer";
 import ChartsContainer from "./ChartsContainer";
 import { calculateSuccessRate } from "./utils";
+import ResourceUsageContainer from "./ResourceUsageContainer";
 
 const Dashboard = () => {
     const [dashboardData, setDashboardData] = useState({
@@ -64,10 +65,10 @@ const Dashboard = () => {
     return (
         <Box
             sx={{
-                height: "100vh",
                 display: "flex",
                 flexDirection: "column",
                 p: 3,
+                overflow: "auto",
             }}
         >
             {error && <ErrorDisplay message={error} />}
@@ -88,6 +89,8 @@ const Dashboard = () => {
                 jobs={dashboardData.jobs}
                 queues={dashboardData.queues}
             />
+
+            <ResourceUsageContainer />
         </Box>
     );
 };

--- a/frontend/src/components/dashboard/PodMetricsTable.jsx
+++ b/frontend/src/components/dashboard/PodMetricsTable.jsx
@@ -1,0 +1,52 @@
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableContainer,
+    TableHead,
+    TableRow,
+} from "@mui/material";
+
+const PodMetricsTable = ({ podMetrics }) => {
+    return (
+        <TableContainer
+            sx={{
+                width: "100%",
+                maxHeight: 410,
+                display: "flex",
+                justifyContent: "center",
+                background: "transparent",
+            }}
+        >
+            <Table stickyHeader sx={{ maxWidth: 650 }} size="small">
+                <TableHead>
+                    <TableRow>
+                        <TableCell>(index)</TableCell>
+                        <TableCell align="right">Pod Name</TableCell>
+                        <TableCell align="right">CPU (cores)</TableCell>
+                        <TableCell align="right">Memory (bytes)</TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {podMetrics?.map((pod, index) => (
+                        <TableRow
+                            key={pod.name}
+                            sx={{
+                                "&:last-child td, &:last-child th": {
+                                    border: 0,
+                                },
+                            }}
+                        >
+                            <TableCell>{index}</TableCell>
+                            <TableCell align="right">{pod.name}</TableCell>
+                            <TableCell align="right">{pod.cpu}</TableCell>
+                            <TableCell align="right">{pod.memory}</TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </TableContainer>
+    );
+};
+
+export default PodMetricsTable;

--- a/frontend/src/components/dashboard/ResourceUsageContainer.jsx
+++ b/frontend/src/components/dashboard/ResourceUsageContainer.jsx
@@ -1,0 +1,202 @@
+import { useEffect, useRef, useState } from "react";
+import { Paper, Typography } from "@mui/material";
+import {
+    Chart as ChartJS,
+    LineElement,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    Tooltip,
+    Legend,
+    Filler,
+} from "chart.js";
+import { Line } from "react-chartjs-2";
+import PodMetricsTable from "./PodMetricsTable";
+
+ChartJS.register(
+    LineElement,
+    CategoryScale,
+    LinearScale,
+    PointElement,
+    Tooltip,
+    Legend,
+    Filler,
+);
+
+const options = {
+    responsive: true,
+    animation: false,
+    maintainAspectRatio: false,
+    scales: {
+        y: {
+            min: 0,
+            max: 100,
+            ticks: { stepSize: 25 },
+            title: {
+                display: true,
+                text: "Usage (%)",
+            },
+        },
+        x: {
+            ticks: false,
+            title: {
+                display: false,
+                text: "Time",
+            },
+        },
+    },
+    plugins: {
+        legend: { position: "top" },
+    },
+};
+
+const ResourceUsageContainer = () => {
+    const [labels, setLabels] = useState(Array(60).fill(0));
+    const [cpuData, setCpuData] = useState([]);
+    const [memoryData, setMemoryData] = useState([]);
+    const [podMetrics, setPodMetrics] = useState([]);
+    const esRef = useRef(null);
+
+    const getResourceMetrics = async () => {
+        try {
+            esRef.current = new EventSource("/api/metrics");
+
+            esRef.current.onmessage = (event) => {
+                const { podMetrics, nodeMetrics: metrics } = JSON.parse(
+                    event.data,
+                );
+
+                setPodMetrics(podMetrics);
+
+                const now = new Date().toLocaleTimeString();
+
+                const totalMetrics = {
+                    cpu_requestTotal: 0,
+                    cpu_capacity: 0,
+                    mem_requestTotal: 0,
+                    mem_capacity: 0,
+                };
+
+                metrics.forEach((metric) => {
+                    totalMetrics.cpu_requestTotal += parseFloat(
+                        metric.cpu.RequestTotal,
+                    );
+                    totalMetrics.cpu_capacity += parseFloat(
+                        metric.cpu.Capacity,
+                    );
+                    totalMetrics.mem_requestTotal += parseFloat(
+                        metric.memory.RequestTotal,
+                    );
+                    totalMetrics.mem_capacity += parseFloat(
+                        metric.memory.Capacity,
+                    );
+                });
+
+                const cpuUsage =
+                    totalMetrics.cpu_capacity === 0
+                        ? 0
+                        : (totalMetrics.cpu_requestTotal /
+                              totalMetrics.cpu_capacity) *
+                          100;
+
+                const memUsage =
+                    totalMetrics.mem_capacity === 0
+                        ? 0
+                        : (totalMetrics.mem_requestTotal /
+                              totalMetrics.mem_capacity) *
+                          100;
+
+                setLabels((prev) => [...prev.slice(-59), now]);
+                setCpuData((prev) => [...prev.slice(-59), cpuUsage.toFixed(2)]);
+                setMemoryData((prev) => [
+                    ...prev.slice(-59),
+                    memUsage.toFixed(2),
+                ]);
+            };
+        } catch (error) {
+            console.error("Error fetching resource metrics:", error);
+        }
+    };
+
+    useEffect(() => {
+        getResourceMetrics();
+
+        return () => {
+            if (esRef.current) {
+                esRef.current.close();
+            }
+        };
+    }, []);
+
+    const cpu_data = {
+        labels,
+        datasets: [
+            {
+                label: "CPU Usage (%)",
+                data: cpuData,
+                fill: true,
+                borderColor: "rgb(75, 192, 192)",
+                backgroundColor: "rgba(75, 192, 192, 0.2)",
+                tension: 0.1,
+                pointRadius: 0,
+            },
+        ],
+    };
+
+    const memory_data = {
+        labels,
+        datasets: [
+            {
+                label: "Memory Usage (%)",
+                data: memoryData,
+                fill: true,
+                borderColor: "rgb(255, 99, 132)",
+                backgroundColor: "rgba(255, 99, 132, 0.2)",
+                tension: 0.1,
+                pointRadius: 0,
+            },
+        ],
+    };
+
+    return (
+        <div style={{ background: "#f5f5f5", padding: "20px", width: "100%" }}>
+            <Typography variant="h5" style={{ margin: "5px 0 5px 0" }}>
+                Resource Usage
+            </Typography>
+            <div
+                style={{
+                    display: "flex",
+                    flexDirection: "row",
+                    alignItems: "start",
+                    justifyContent: "space-around",
+                    gap: "20px",
+                    width: "100%",
+                    marginTop: "5px",
+                }}
+            >
+                <ResourceGraph data={cpu_data} />
+                <ResourceGraph data={memory_data} />
+            </div>
+            <div style={{ marginTop: "20px", width: "100%" }}>
+                <PodMetricsTable podMetrics={podMetrics} />
+            </div>
+        </div>
+    );
+};
+
+const ResourceGraph = ({ data }) => {
+    return (
+        <Paper
+            sx={{
+                p: 2,
+                width: "100%",
+                maxWidth: "50%",
+                height: "400px",
+            }}
+        >
+            <Line data={data} options={options} />
+        </Paper>
+    );
+};
+
+export default ResourceUsageContainer;

--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,7 @@
                 "@mui/material": "^6.4.4",
                 "axios": "^1.7.9",
                 "bootstrap": "^5.3.5",
-                "chart.js": "^4.4.7",
+                "chart.js": "^4.4.9",
                 "dotenv": "^16.4.7",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",


### PR DESCRIPTION
## Describe the PR

This PR adds the feature for `real-time` cpu and memory usage graphs. Along with it also shows the top-pods.

### Screenshots

![res-usage](https://github.com/user-attachments/assets/7c19a88b-56ee-4373-a657-fdd50d080b73)

## Additional Context

In order to test this PR, you would require `metrics-server`
```sh
kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/latest/download/components.yaml
```
then try running your jobs (tasks).