### PR TITLE
fix Jobs tab namespace selection

### DIFF
--- a/frontend/src/components/jobs/JobTable/JobTableHeader.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTableHeader.jsx
@@ -8,9 +8,10 @@ import {
     Box,
     useTheme,
     alpha,
+    Menu,
+    MenuItem,
 } from "@mui/material";
-import { ArrowDownward, ArrowUpward, UnfoldMore } from "@mui/icons-material";
-import JobFilters from "./JobFilters";
+import { ArrowDownward, ArrowUpward, UnfoldMore, FilterList } from "@mui/icons-material";
 
 const JobTableHeader = ({
     filters,
@@ -24,6 +25,67 @@ const JobTableHeader = ({
     toggleSortDirection,
 }) => {
     const theme = useTheme();
+
+    const renderFilterButton = (filterType, currentValue, options, anchorElForFilter) => (
+        <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1 }}>
+            <Button
+                size="small"
+                variant="outlined"
+                onClick={(event) => handleFilterClick(filterType, event)}
+                startIcon={<FilterList fontSize="small" />}
+                sx={{
+                    textTransform: "none",
+                    padding: "4px 12px",
+                    minWidth: "auto",
+                    borderRadius: "20px",
+                    fontSize: "0.8rem",
+                    fontWeight: 500,
+                    letterSpacing: "0.02em",
+                    backgroundColor: alpha(theme.palette.primary.main, 0.1),
+                    color: theme.palette.primary.main,
+                    borderColor: alpha(theme.palette.primary.main, 0.3),
+                    "&:hover": {
+                        backgroundColor: alpha(theme.palette.primary.main, 0.15),
+                        borderColor: theme.palette.primary.main,
+                        transform: "translateY(-2px)",
+                    },
+                }}
+            >
+                {currentValue === "All" ? "Filter" : currentValue}
+            </Button>
+            <Menu
+                anchorEl={anchorElForFilter}
+                open={Boolean(anchorElForFilter)}
+                onClose={() => handleFilterClose(filterType, currentValue)}
+                PaperProps={{
+                    sx: {
+                        maxHeight: 300,
+                        minWidth: 150,
+                        borderRadius: 2,
+                        boxShadow: theme.shadows[8],
+                    },
+                }}
+            >
+                {options.map((option) => (
+                    <MenuItem
+                        key={option}
+                        onClick={() => handleFilterClose(filterType, option)}
+                        selected={currentValue === option}
+                        sx={{
+                            "&.Mui-selected": {
+                                backgroundColor: alpha(theme.palette.primary.main, 0.1),
+                                "&:hover": {
+                                    backgroundColor: alpha(theme.palette.primary.main, 0.2),
+                                },
+                            },
+                        }}
+                    >
+                        {option}
+                    </MenuItem>
+                ))}
+            </Menu>
+        </Box>
+    );
 
     return (
         <TableHead>
@@ -49,48 +111,47 @@ const JobTableHeader = ({
                     </Typography>
                 </TableCell>
 
-                {["Namespace", "Queue"].map((field) => (
-                    <TableCell
-                        key={field}
-                        sx={{
-                            backgroundColor: alpha(
-                                theme.palette.background.paper,
-                                0.8,
-                            ),
-                            backdropFilter: "blur(8px)",
-                            padding: "16px 24px",
-                            borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.2)}`,
-                        }}
+                <TableCell
+                    sx={{
+                        backgroundColor: alpha(
+                            theme.palette.background.paper,
+                            0.8,
+                        ),
+                        backdropFilter: "blur(8px)",
+                        padding: "16px 24px",
+                        borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+                    }}
+                >
+                    <Typography
+                        variant="subtitle1"
+                        fontWeight="700"
+                        color="text.primary"
                     >
-                        <Box
-                            sx={{
-                                display: "flex",
-                                alignItems: "center",
-                                gap: "8px",
-                            }}
-                        >
-                            <Typography
-                                variant="subtitle1"
-                                fontWeight="700"
-                                color="text.primary"
-                            >
-                                {field}
-                            </Typography>
-                            <JobFilters
-                                filterType={field.toLowerCase()}
-                                currentValue={filters[field.toLowerCase()]}
-                                options={
-                                    field === "Namespace"
-                                        ? allNamespaces
-                                        : allQueues
-                                }
-                                handleFilterClick={handleFilterClick}
-                                handleFilterClose={handleFilterClose}
-                                anchorEl={anchorEl[field.toLowerCase()]}
-                            />
-                        </Box>
-                    </TableCell>
-                ))}
+                        Namespace
+                    </Typography>
+                    {renderFilterButton("namespace", filters.namespace, ["All", ...allNamespaces], anchorEl.namespace)}
+                </TableCell>
+
+                <TableCell
+                    sx={{
+                        backgroundColor: alpha(
+                            theme.palette.background.paper,
+                            0.8,
+                        ),
+                        backdropFilter: "blur(8px)",
+                        padding: "16px 24px",
+                        borderBottom: `2px solid ${alpha(theme.palette.primary.main, 0.2)}`,
+                    }}
+                >
+                    <Typography
+                        variant="subtitle1"
+                        fontWeight="700"
+                        color="text.primary"
+                    >
+                        Queue
+                    </Typography>
+                    {renderFilterButton("queue", filters.queue, ["All", ...allQueues], anchorEl.queue)}
+                </TableCell>
 
                 <TableCell
                     sx={{
@@ -169,17 +230,9 @@ const JobTableHeader = ({
                     >
                         Status
                     </Typography>
-                    <JobFilters
-                        filterType="status"
-                        currentValue={filters.status}
-                        options={uniqueStatuses}
-                        handleFilterClick={handleFilterClick}
-                        handleFilterClose={handleFilterClose}
-                        anchorEl={anchorEl.status}
-                    />
+                    {renderFilterButton("status", filters.status, uniqueStatuses, anchorEl.status)}
                 </TableCell>
 
-                {/* New Actions Column */}
                 <TableCell
                     sx={{
                         backgroundColor: alpha(

--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -17,7 +17,7 @@ const Jobs = () => {
     const [allQueues, setAllQueues] = useState([]);
     const [filters, setFilters] = useState({
         status: "All",
-        namespace: "default",
+        namespace: "All",
         queue: "All",
     });
     const [selectedJobYaml, setSelectedJobYaml] = useState("");
@@ -42,13 +42,18 @@ const Jobs = () => {
         setError(null);
 
         try {
+            const params = {
+                search: searchText,
+                queue: filters.queue,
+                status: filters.status,
+            };
+
+            if (filters.namespace !== "All") {
+                params.namespace = filters.namespace;
+            }
+
             const response = await axios.get(`/api/jobs`, {
-                params: {
-                    search: searchText,
-                    namespace: filters.namespace,
-                    queue: filters.queue,
-                    status: filters.status,
-                },
+                params: params,
             });
 
             if (response.status !== 200) {
@@ -191,9 +196,12 @@ const Jobs = () => {
             const statusMatch =
                 filters.status === "All" ||
                 (job.status && job.status.state.phase === filters.status);
+            const namespaceMatch =
+                filters.namespace === "All" || 
+                job.metadata.namespace === filters.namespace;
             const queueMatch =
                 filters.queue === "All" || job.spec.queue === filters.queue;
-            return statusMatch && queueMatch;
+            return statusMatch && namespaceMatch && queueMatch;
         });
     }, [jobs, filters]);
 


### PR DESCRIPTION
Addresses #159 

- Changed default namespace filter from "default" to "All", and only send ?namespace= when a specific namespace is chosen.

- Updated header to show a “Filter” button next to Namespace, Queue, and Status, injecting "All" at the top of each menu.

- Now the Namespace dropdown opens correctly and lists “All” plus every namespace.