### PR TITLE
Add helm chart for dashboard deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,27 +21,107 @@ Before installing the volcano dashboard, please ensure you have:
 
 ### Install Volcano Dashboard
 
-1. Create the volcano-system namespace (if it doesn't exist):
+Create the volcano-system namespace (if it doesn't exist):
 
 ```bash
 kubectl create ns volcano-system
 ```
 
-2. Deploy the volcano dashboard:
+Deploy the volcano dashboard:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/volcano-sh/dashboard/main/deployment/volcano-dashboard.yaml
 ```
 
-3. Access the dashboard by port-forwarding the service:
+### Installing Volcano Dashboard via helm charts
+
+To install the volcano dashboard with chart:
+
+```bash
+helm install <specified-name> ./installer/helm/chart/volcano-dashboard --namespace <namespace> --create-namespace
+
+e.g :
+helm install volcano-dashboard ./installer/helm/chart/volcano-dashboard --namespace volcano-system --create-namespace
+```
+
+This command deploys volcano dashboard in kubernetes cluster with default configuration.  The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+To list the volcano dashboard chart:
+
+```bash
+helm list -n <namespace>
+
+e.g:
+ helm list -n volcano-system
+```
+
+### Uninstalling the Chart
+
+```bash
+$ helm delete volcano-dashboard -n volcano-system
+```
+
+### Configuration
+
+The following are the list configurable parameters of Volcano Dashboard Chart and their default values.
+
+| Parameter|Description|Default Value|
+|----------------|-----------------|----------------------|
+|`basic.frontend_image_name`|Frontend Docker Image Name|`volcanosh/vc-dashboard-frontend`|
+|`basic.backend_image_name`|Backend Docker Image Name|`volcanosh/vc-dashboard-backend`|
+|`basic.image_tag_version`|Docker image version Tag|`latest`|
+|`basic.frontend_image_tag_version`|Override tag for the frontend only|`""`|
+|`basic.backend_image_tag_version`|Override tag for the backend only|`""`|
+|`basic.image_registry`|Container image registry|`docker.io`|
+|`basic.image_pull_policy`|Image Pull Policy|`Always`|
+|`basic.image_pull_secret`|Image Pull Secret|`""`|
+|`custom.dashboard_replicas`|The number of dashboard pods to run|`1`|
+|`custom.dashboard_enable`|Enable / disable the whole deployment|`true`|
+|`custom.service_type`|Kubernetes service type|`ClusterIP`|
+|`custom.frontend_node_port`|NodePort for frontend|`~`|
+|`custom.backend_node_port`|NodePort for backend|`~`|
+|`custom.default_sc`|Default securityContext for dashboard pods|`~`|
+|`custom.default_csc`|Container security context defaults|`~`|
+|`custom.frontend_csc`|Per-container security context overrides for frontend|`~`|
+|`custom.backend_csc`|Per-container security context overrides for backend|`~`|
+|`custom.frontend_resources`|Resource requests/limits for the frontend container|`~`|
+|`custom.backend_resources`|Resource requests/limits for the backend container|`~`|
+|`custom.dashboard_ns`|Node selector for the dashboard pod|`~`|
+|`custom.dashboard_affinity`|Affinity rules for the dashboard pod|`~`|
+|`custom.dashboard_tolerations`|Tolerations for the dashboard pod|`~`|
+|`custom.common_labels`|Additional labels for all Helm chart objects|`~`|
+|`custom.dashboard_labels`|Additional labels for the Deployment object|`~`|
+|`custom.dashboard_pod_labels`|Additional labels for Dashboard pods|`~`|
+|`service.ipFamilyPolicy`|Settings service the family policy|`""`|
+|`service.ipFamilies`|Settings service the address families|`[]`|
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```bash
+$ helm install volcano-dashboard --set custom.service_type=NodePort ./installer/helm/chart/volcano-dashboard -n volcano-system
+```
+
+The above command set service type to `NodePort`, so the dashboard can be accessed via Node IP directly.
+
+Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
+
+```bash
+$ helm install volcano-dashboard -f values.yaml ./installer/helm/chart/volcano-dashboard -n volcano-system
+```
+
+> **Tip**: You can use the default [values.yaml](installer/helm/chart/volcano-dashboard/values.yaml)
+
+### Access the dashboard
+
+Access the dashboard by port-forwarding the service:
 
 ```bash
 kubectl port-forward svc/volcano-dashboard 8080:80 -n volcano-system --address 0.0.0.0
 ```
 
-4. Open your browser and navigate to:
-   - For local access: `http://localhost:8080`
-   - For remote access: `http://<NODE_IP>:8080` (replace `<NODE_IP>` with your Kubernetes node's IP address)
+Then open your browser and navigate to:
+- For local access: `http://localhost:8080`
+- For remote access: `http://<NODE_IP>:8080` (replace `<NODE_IP>` with your Kubernetes node's IP address)
 
 ## Contributing
 

--- a/installer/helm/chart/volcano-dashboard/Chart.yaml
+++ b/installer/helm/chart/volcano-dashboard/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Helm chart for Volcano Dashboard
 name: volcano-dashboard
 version: "0.1.0"
-appVersion: "latest"
+appVersion: "v0.2.0"
 icon: https://raw.githubusercontent.com/volcano-sh/volcano/master/docs/images/volcano-logo.png
 home: https://volcano.sh
 sources:

--- a/installer/helm/chart/volcano-dashboard/Chart.yaml
+++ b/installer/helm/chart/volcano-dashboard/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+description: A Helm chart for Volcano Dashboard
+name: volcano-dashboard
+version: "0.1.0"
+appVersion: "latest"
+icon: https://raw.githubusercontent.com/volcano-sh/volcano/master/docs/images/volcano-logo.png
+home: https://volcano.sh
+sources:
+  - https://github.com/volcano-sh/dashboard
+# maintainers:
+  # - name: 
+    # email: 

--- a/installer/helm/chart/volcano-dashboard/templates/NOTES.txt
+++ b/installer/helm/chart/volcano-dashboard/templates/NOTES.txt
@@ -1,0 +1,13 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}, deployed into namespace {{ .Release.Namespace }}.
+
+To access the Volcano Dashboard, run the following command:
+
+  kubectl port-forward svc/{{ .Release.Name }} 8080:80 -n {{ .Release.Namespace }}
+
+Then open your browser and navigate to:
+  http://localhost:8080
+
+For more information on Volcano, visit:
+  https://volcano.sh/

--- a/installer/helm/chart/volcano-dashboard/templates/_helpers.tpl
+++ b/installer/helm/chart/volcano-dashboard/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "volcano-dashboard.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name using the release name.
+Truncate to 63 chars because Kubernetes label values must be no longer than 63 characters.
+*/}}
+{{- define "volcano-dashboard.fullname" -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels added to every resource (when common_labels is set).
+*/}}
+{{- define "volcano-dashboard.labels" -}}
+{{- if .Values.custom.common_labels }}
+{{- toYaml .Values.custom.common_labels }}
+{{- end }}
+{{- end }}

--- a/installer/helm/chart/volcano-dashboard/templates/dashboard.yaml
+++ b/installer/helm/chart/volcano-dashboard/templates/dashboard.yaml
@@ -20,7 +20,7 @@ metadata:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}
   {{- if .Values.custom.common_labels }}
   labels:
     {{- toYaml .Values.custom.common_labels | nindent 4 }}
@@ -82,7 +82,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ .Release.Name }}-role
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}-role
   {{- if .Values.custom.common_labels }}
   labels:
     {{- toYaml .Values.custom.common_labels | nindent 4 }}
@@ -90,7 +90,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ .Release.Name }}
+  name: {{ .Release.Name }}-{{ .Release.Namespace }}
 subjects:
   - kind: ServiceAccount
     name: {{ .Release.Name }}
@@ -105,7 +105,7 @@ metadata:
   labels:
     app: volcano-dashboard
     {{- if or (.Values.custom.dashboard_labels) (.Values.custom.common_labels) }}
-    {{- mustMerge (.Values.custom.dashboard_labels | default (dict)) (.Values.custom.common_labels | default (dict)) | toYaml | nindent 4 }}
+    {{- mustMerge (dict) (.Values.custom.dashboard_labels | default (dict)) (.Values.custom.common_labels | default (dict)) | toYaml | nindent 4 }}
     {{- end }}
 spec:
   replicas: {{ .Values.custom.dashboard_replicas }}
@@ -117,7 +117,7 @@ spec:
       labels:
         app: volcano-dashboard
         {{- if or (.Values.custom.dashboard_pod_labels) (.Values.custom.common_labels) }}
-        {{- mustMerge (.Values.custom.dashboard_pod_labels | default (dict)) (.Values.custom.common_labels | default (dict)) | toYaml | nindent 8 }}
+        {{- mustMerge (dict) (.Values.custom.dashboard_pod_labels | default (dict)) (.Values.custom.common_labels | default (dict)) | toYaml | nindent 8 }}
         {{- end }}
     spec:
       {{- if $dashboard_tolerations }}

--- a/installer/helm/chart/volcano-dashboard/templates/dashboard.yaml
+++ b/installer/helm/chart/volcano-dashboard/templates/dashboard.yaml
@@ -1,0 +1,224 @@
+{{- if .Values.custom.dashboard_enable }}
+{{- $dashboard_sc := .Values.custom.default_sc }}
+{{- $dashboard_frontend_csc := or .Values.custom.frontend_csc .Values.custom.default_csc }}
+{{- $dashboard_backend_csc := or .Values.custom.backend_csc .Values.custom.default_csc }}
+{{- $dashboard_ns := .Values.custom.dashboard_ns }}
+{{- $dashboard_affinity := .Values.custom.dashboard_affinity }}
+{{- $dashboard_tolerations := .Values.custom.dashboard_tolerations }}
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  {{- if .Values.custom.common_labels }}
+  labels:
+    {{- toYaml .Values.custom.common_labels | nindent 4 }}
+  {{- end }}
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}
+  {{- if .Values.custom.common_labels }}
+  labels:
+    {{- toYaml .Values.custom.common_labels | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+      - batch.volcano.sh
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+
+  - apiGroups:
+      - scheduling.incubator.k8s.io
+      - scheduling.volcano.sh
+    resources:
+      - queues
+    verbs:
+      - get
+      - list
+      - watch
+      - delete
+      - create
+      - update
+      - patch
+
+  - apiGroups:
+      - scheduling.volcano.sh
+    resources:
+      - podgroups
+    verbs:
+      - get
+      - list
+      - watch
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-role
+  {{- if .Values.custom.common_labels }}
+  labels:
+    {{- toYaml .Values.custom.common_labels | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}
+    namespace: {{ .Release.Namespace }}
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: volcano-dashboard
+    {{- if or (.Values.custom.dashboard_labels) (.Values.custom.common_labels) }}
+    {{- mustMerge (.Values.custom.dashboard_labels | default (dict)) (.Values.custom.common_labels | default (dict)) | toYaml | nindent 4 }}
+    {{- end }}
+spec:
+  replicas: {{ .Values.custom.dashboard_replicas }}
+  selector:
+    matchLabels:
+      app: volcano-dashboard
+  template:
+    metadata:
+      labels:
+        app: volcano-dashboard
+        {{- if or (.Values.custom.dashboard_pod_labels) (.Values.custom.common_labels) }}
+        {{- mustMerge (.Values.custom.dashboard_pod_labels | default (dict)) (.Values.custom.common_labels | default (dict)) | toYaml | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- if $dashboard_tolerations }}
+      tolerations:
+        {{- toYaml $dashboard_tolerations | nindent 8 }}
+      {{- end }}
+      {{- if $dashboard_ns }}
+      nodeSelector:
+        {{- toYaml $dashboard_ns | nindent 8 }}
+      {{- end }}
+      {{- if $dashboard_affinity }}
+      affinity:
+        {{- toYaml $dashboard_affinity | nindent 8 }}
+      {{- end }}
+      {{- if $dashboard_sc }}
+      securityContext:
+        {{- toYaml $dashboard_sc | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Release.Name }}
+      {{- if .Values.basic.image_pull_secret }}
+      imagePullSecrets:
+        - name: {{ .Values.basic.image_pull_secret }}
+      {{- end }}
+      containers:
+        
+        - name: frontend
+          image: {{ .Values.basic.image_registry }}/{{ .Values.basic.frontend_image_name }}:{{ .Values.basic.frontend_image_tag_version | default .Values.basic.image_tag_version }}
+          imagePullPolicy: {{ .Values.basic.image_pull_policy }}
+          ports:
+            - containerPort: 8080
+              name: frontend
+              protocol: TCP
+          {{- if .Values.custom.frontend_resources }}
+          resources:
+            {{- toYaml .Values.custom.frontend_resources | nindent 12 }}
+          {{- end }}
+          {{- if $dashboard_frontend_csc }}
+          securityContext:
+            {{- toYaml $dashboard_frontend_csc | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - mountPath: /var/cache/nginx
+              name: nginx-cache
+            - mountPath: /run
+              name: nginx-run
+        
+        - name: backend
+          image: {{ .Values.basic.image_registry }}/{{ .Values.basic.backend_image_name }}:{{ .Values.basic.backend_image_tag_version | default .Values.basic.image_tag_version }}
+          imagePullPolicy: {{ .Values.basic.image_pull_policy }}
+          ports:
+            - containerPort: 3001
+              name: backend
+              protocol: TCP
+          {{- if .Values.custom.backend_resources }}
+          resources:
+            {{- toYaml .Values.custom.backend_resources | nindent 12 }}
+          {{- end }}
+          {{- if $dashboard_backend_csc }}
+          securityContext:
+            {{- toYaml $dashboard_backend_csc | nindent 12 }}
+          {{- end }}
+      volumes:
+        - name: nginx-cache
+          emptyDir: {}
+        - name: nginx-run
+          emptyDir: {}
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: volcano-dashboard
+    {{- if .Values.custom.common_labels }}
+    {{- toYaml .Values.custom.common_labels | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.custom.service_type }}
+  {{- if .Values.service.ipFamilyPolicy }}
+  ipFamilyPolicy: {{ .Values.service.ipFamilyPolicy }}
+  {{- end }}
+  {{- if .Values.service.ipFamilies }}
+  ipFamilies: {{ toYaml .Values.service.ipFamilies | nindent 4 }}
+  {{- end }}
+  ports:
+    - name: frontend
+      port: 80
+      protocol: TCP
+      targetPort: 8080
+      {{- if and (eq .Values.custom.service_type "NodePort") .Values.custom.frontend_node_port }}
+      nodePort: {{ .Values.custom.frontend_node_port }}
+      {{- end }}
+    - name: backend
+      port: 3001
+      protocol: TCP
+      targetPort: 3001
+      {{- if and (eq .Values.custom.service_type "NodePort") .Values.custom.backend_node_port }}
+      nodePort: {{ .Values.custom.backend_node_port }}
+      {{- end }}
+  selector:
+    app: volcano-dashboard
+{{- end }}

--- a/installer/helm/chart/volcano-dashboard/values.yaml
+++ b/installer/helm/chart/volcano-dashboard/values.yaml
@@ -1,0 +1,82 @@
+basic:
+  frontend_image_name: "volcanosh/vc-dashboard-frontend"
+  backend_image_name: "volcanosh/vc-dashboard-backend"
+  image_tag_version: "latest"
+  frontend_image_tag_version: ""
+  backend_image_tag_version: ""
+  image_registry: "docker.io"
+  image_pull_policy: "Always"
+  image_pull_secret: ""
+
+custom:
+  dashboard_replicas: 1
+  dashboard_enable: true
+
+  # Service type: ClusterIP, NodePort, LoadBalancer
+  service_type: "ClusterIP"
+
+  # NodePort values (only used when service_type is NodePort)
+  frontend_node_port: ~
+  backend_node_port: ~
+  default_sc:
+    seccompProfile:
+      type: RuntimeDefault
+    seLinuxOptions:
+      level: "s0:c123,c456"
+  default_csc:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    runAsNonRoot: true
+    runAsUser: 1000
+  frontend_csc: ~
+  backend_csc: ~
+
+  # Resource requests/limits for the frontend container
+  # Example:
+  #   frontend_resources:
+  #     requests:
+  #       cpu: 100m
+  #       memory: 128Mi
+  #     limits:
+  #       cpu: 200m
+  #       memory: 256Mi
+  frontend_resources: ~
+
+  # Resource requests/limits for the backend container
+  backend_resources: ~
+
+  # Node selector (applied to the dashboard pod)
+  # Example:
+  #   dashboard_ns:
+  #     nodetype: criticalservices
+  dashboard_ns: ~
+
+  # Affinity rules for the dashboard pod
+  # Example:
+  #   dashboard_affinity:
+  #     podAntiAffinity:
+  #       preferredDuringSchedulingIgnoredDuringExecution:
+  #         - weight: 49
+  #           podAffinityTerm:
+  #             topologyKey: kubernetes.io/hostname
+  #             labelSelector:
+  #               matchLabels:
+  #                 app: volcano-dashboard
+  dashboard_affinity: ~
+
+  # Tolerations for the dashboard pod
+  # Example:
+  #   dashboard_tolerations:
+  #     - key: "example-key"
+  #       operator: "Exists"
+  #       effect: "NoSchedule"
+  dashboard_tolerations: ~
+  common_labels: ~
+  dashboard_labels: ~
+  dashboard_pod_labels: ~
+
+service:
+  ipFamilyPolicy: ""
+  ipFamilies: []


### PR DESCRIPTION
this pr introduces helm chart support for the volcano dashboard mirroring the standard installation pattern used in the core volcano repository.

Resolves: #176

### Verification Steps

reviewers can follow these steps on a local kubernetes cluster (such as minikube or kind):

**1. Checkout this branch and navigate to the root directory:**
```bash
git checkout install-via-helm
```

**2. Lint the Helm chart to ensure syntax is correct:**
```bash
helm lint ./installer/helm/chart/volcano-dashboard
```

**3. Install the Helm chart:**
```bash
kubectl create namespace volcano-system
helm install volcano-dashboard ./installer/helm/chart/volcano-dashboard --namespace volcano-system
```

**4. Verify the resources are running:**
```bash
kubectl get pods,svc,sa,clusterrole,clusterrolebinding -n volcano-system -l app=volcano-dashboard
```
*(Wait until the `volcano-dashboard` pod shows a `Running` status).*

**5. Port-forward the dashboard UI:**
```bash
kubectl port-forward svc/volcano-dashboard 8080:80 -n volcano-system
```

**6. Access the Dashboard:**
Open your browser and navigate to `http://localhost:8080`. The Volcano Dashboard UI should load successfully.

**7. Clean up (Optional):**
```bash
helm uninstall volcano-dashboard -n volcano-system
```

Note: i have commented out maintainer details (empty values) in Chart.yaml file as it needs to be reviewed.