### PR TITLE
fix: preserve filter state when PodsTable filter menu is dismissed

### DIFF
--- a/frontend/src/components/pods/PodsTable/PodsTable.jsx
+++ b/frontend/src/components/pods/PodsTable/PodsTable.jsx
@@ -31,7 +31,13 @@ const PodsTable = ({
 
     const handleFilterClose = React.useCallback(
         (filterType, value) => {
-            onFilterChange(filterType, value);
+            // Only update the active filter when the user explicitly selects a
+            // value.  When the menu is dismissed (click-away / Escape), MUI
+            // calls onClose with no event argument so value arrives as null —
+            // propagating that would silently overwrite the current filter.
+            if (value !== null && value !== undefined) {
+                onFilterChange(filterType, value);
+            }
             setAnchorEl((prev) => ({ ...prev, [filterType]: null }));
         },
         [onFilterChange],

--- a/frontend/tests/PodsTableFilter.test.jsx
+++ b/frontend/tests/PodsTableFilter.test.jsx
@@ -1,0 +1,78 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { ThemeProvider, createTheme } from "@mui/material/styles";
+import PodsTable from "../src/components/pods/PodsTable/PodsTable";
+
+const theme = createTheme();
+
+const mockPods = [
+    {
+        metadata: {
+            name: "pod-a",
+            namespace: "default",
+            creationTimestamp: new Date().toISOString(),
+        },
+        status: { phase: "Running" },
+        spec: {},
+    },
+    {
+        metadata: {
+            name: "pod-b",
+            namespace: "kube-system",
+            creationTimestamp: new Date().toISOString(),
+        },
+        status: { phase: "Pending" },
+        spec: {},
+    },
+];
+
+const renderTable = (onFilterChange) =>
+    render(
+        <ThemeProvider theme={theme}>
+            <PodsTable
+                pods={mockPods}
+                filters={{ status: "All", namespace: "default" }}
+                allNamespaces={["default", "kube-system"]}
+                sortDirection="desc"
+                onSortDirectionToggle={() => {}}
+                onFilterChange={onFilterChange}
+                onPodClick={() => {}}
+            />
+        </ThemeProvider>,
+    );
+
+describe("PodsTable filter", () => {
+    it("calls onFilterChange with the selected value when an item is clicked", () => {
+        const onFilterChange = vi.fn();
+        renderTable(onFilterChange);
+
+        const statusFilterBtn = screen.getByRole("button", {
+            name: /filter: all/i,
+        });
+        fireEvent.click(statusFilterBtn);
+
+        const runningOption = screen.getByText("Running");
+        fireEvent.click(runningOption);
+
+        expect(onFilterChange).toHaveBeenCalledWith("status", "Running");
+        expect(onFilterChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("does NOT call onFilterChange when the menu is dismissed without a selection", () => {
+        const onFilterChange = vi.fn();
+        renderTable(onFilterChange);
+
+        const statusFilterBtn = screen.getByRole("button", {
+            name: /filter: all/i,
+        });
+        fireEvent.click(statusFilterBtn);
+
+        // Simulate MUI Menu calling onClose with no selected value (dismiss)
+        const menu = document.querySelector('[role="presentation"]');
+        if (menu) {
+            fireEvent.keyDown(menu, { key: "Escape" });
+        }
+
+        expect(onFilterChange).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #97

When a MUI `Menu` is dismissed without selecting an item (click-away or Escape key), MUI calls the `onClose` handler with `null` as the reason value. The previous `handleFilterClose` in `PodsTable` forwarded that `null` directly to `onFilterChange`, which silently set e.g. `filters.status = null`. This broke the filter button label (showed `"Filter: null"`) and corrupted the active filter on every accidental dismiss.

**Root cause:** `handleFilterClose` did not distinguish between a dismissal and an explicit selection.

**Fix:** Added a `value !== null && value !== undefined` guard in `handleFilterClose` — the anchor element is always cleared, but `onFilterChange` is only called when the user actually picked a value.

This is more correct than the fix in PR #98 (which only patched `FilterMenu`), because the real invariant belongs to the parent: the table owns filter state and should never accept `null` as a filter value from a dismiss event.

## Changes
- `PodsTable.jsx` — guard in `handleFilterClose` skips `onFilterChange` when `value` is null/undefined
- `PodsTableFilter.test.jsx` — two new tests:
  1. Selecting an item calls `onFilterChange` with the correct value
  2. Dismissing the menu (Escape) does **not** call `onFilterChange`

## Test plan
- [ ] Open status filter → click a status → filter label updates correctly
- [ ] Open status filter → press Escape or click outside → filter label stays unchanged
- [ ] Run `npm test` in `frontend/` → both new tests pass