### PR TITLE
feat: add scheduler config and log API endpoints (issue #197)

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -984,6 +984,155 @@ app.delete("/api/queues/:name", async (req, res) => {
     }
 });
 
+// ─── Scheduler API ────────────────────────────────────────────────────────────
+
+const VOLCANO_NAMESPACE = "volcano-system";
+const SCHEDULER_CONFIGMAP = "volcano-scheduler-configmap";
+
+// Component → label selector used to locate the right pod
+const COMPONENT_LABELS = {
+    scheduler: "app=volcano-scheduler",
+    "controller-manager": "app=volcano-controller-manager",
+    "webhook-manager": "app=volcano-webhook-manager",
+    agent: "app=volcano-agent",
+};
+
+/**
+ * Resolve the running pod name for a Volcano component.
+ * Returns the first Running pod matching the component's label selector,
+ * or null when no matching pod is found.
+ */
+async function resolveComponentPod(component) {
+    const labelSelector =
+        COMPONENT_LABELS[component] ||
+        `app=volcano-${component}`;
+
+    const response = await k8sCoreApi.listNamespacedPod({
+        namespace: VOLCANO_NAMESPACE,
+        labelSelector,
+    });
+
+    const pods = (response.items || []).filter(
+        (p) => p.status?.phase === "Running",
+    );
+
+    return pods.length > 0 ? pods[0].metadata.name : null;
+}
+
+// GET /api/scheduler/config
+// Returns the volcano-scheduler-configmap data as JSON.
+app.get("/api/scheduler/config", async (req, res) => {
+    try {
+        const cm = await k8sCoreApi.readNamespacedConfigMap({
+            name: SCHEDULER_CONFIGMAP,
+            namespace: VOLCANO_NAMESPACE,
+        });
+        res.json({
+            name: cm.metadata.name,
+            namespace: cm.metadata.namespace,
+            resourceVersion: cm.metadata.resourceVersion,
+            data: cm.data || {},
+        });
+    } catch (err) {
+        console.error("Error fetching scheduler config:", err);
+        res.status(500).json({
+            error: "Failed to fetch scheduler config",
+            details: err.message,
+        });
+    }
+});
+
+// PATCH /api/scheduler/config
+// Applies a strategic-merge patch to the volcano-scheduler-configmap.
+// Body: { data: { "volcano-scheduler.conf": "<yaml string>" } }
+app.patch("/api/scheduler/config", async (req, res) => {
+    try {
+        const patchBody = req.body;
+
+        if (!patchBody || typeof patchBody !== "object") {
+            return res.status(400).json({ error: "Request body must be a JSON object" });
+        }
+
+        const response = await k8sCoreApi.patchNamespacedConfigMap({
+            name: SCHEDULER_CONFIGMAP,
+            namespace: VOLCANO_NAMESPACE,
+            body: patchBody,
+            options: {
+                headers: { "Content-Type": "application/merge-patch+json" },
+            },
+        });
+
+        res.json({
+            message: "Scheduler config updated successfully",
+            resourceVersion: response.metadata?.resourceVersion,
+        });
+    } catch (err) {
+        console.error("Error patching scheduler config:", err);
+        res.status(500).json({
+            error: "Failed to update scheduler config",
+            details: err?.body?.message || err.message,
+        });
+    }
+});
+
+// GET /api/scheduler/logs
+// Query params:
+//   component  — scheduler | controller-manager | webhook-manager | agent  (default: scheduler)
+//   tailLines  — number of lines to return from the end of the log (default: 100)
+//   container  — optional container name (defaults to first container)
+app.get("/api/scheduler/logs", async (req, res) => {
+    try {
+        const component = req.query.component || "scheduler";
+        const tailLines = Math.min(
+            parseInt(req.query.tailLines) || 100,
+            5000,
+        );
+
+        if (!COMPONENT_LABELS[component]) {
+            return res.status(400).json({
+                error: `Unknown component '${component}'. Valid values: ${Object.keys(COMPONENT_LABELS).join(", ")}`,
+            });
+        }
+
+        const podName = await resolveComponentPod(component);
+
+        if (!podName) {
+            return res.status(404).json({
+                error: `No running pod found for component '${component}' in namespace '${VOLCANO_NAMESPACE}'`,
+            });
+        }
+
+        const logParams = {
+            name: podName,
+            namespace: VOLCANO_NAMESPACE,
+            tailLines,
+            timestamps: true,
+        };
+
+        if (req.query.container) {
+            logParams.container = req.query.container;
+        }
+
+        const logs = await k8sCoreApi.readNamespacedPodLog(logParams);
+
+        res.json({
+            component,
+            pod: podName,
+            namespace: VOLCANO_NAMESPACE,
+            tailLines,
+            logs: typeof logs === "string" ? logs : String(logs),
+        });
+    } catch (err) {
+        console.error("Error fetching scheduler logs:", err);
+        res.status(500).json({
+            error: "Failed to fetch scheduler logs",
+            details: err?.body?.message || err.message,
+        });
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 const verifyVolcanoSetup = async () => {
     try {
         // Verify CRD access

--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -1,7 +1,7 @@
 import sinon from "sinon";
 import request from "supertest";
 import { app } from "../src/server.js";
-import { CustomObjectsApi } from "@kubernetes/client-node";
+import { CustomObjectsApi, CoreV1Api } from "@kubernetes/client-node";
 
 describe("backend", () => {
     let sandbox;
@@ -77,5 +77,90 @@ describe("backend", () => {
         expect(res.status).toBe(200);
         expect(res.body.items).toHaveLength(2);
         expect(res.body.items[0].metadata.name).toBe("pg1");
+    });
+
+    describe("GET /api/scheduler/config", () => {
+        it("returns configmap data on success", async () => {
+            const mockCM = {
+                metadata: {
+                    name: "volcano-scheduler-configmap",
+                    namespace: "volcano-system",
+                    resourceVersion: "12345",
+                },
+                data: {
+                    "volcano-scheduler.conf":
+                        "actions: \"enqueue, allocate\"\nplugins:\n",
+                },
+            };
+
+            sandbox
+                .stub(CoreV1Api.prototype, "readNamespacedConfigMap")
+                .resolves(mockCM);
+
+            const res = await request(app).get("/api/scheduler/config");
+
+            expect(res.status).toBe(200);
+            expect(res.body.name).toBe("volcano-scheduler-configmap");
+            expect(res.body.data).toHaveProperty("volcano-scheduler.conf");
+        });
+
+        it("returns 500 when the k8s call fails", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "readNamespacedConfigMap")
+                .rejects(new Error("forbidden"));
+
+            const res = await request(app).get("/api/scheduler/config");
+
+            expect(res.status).toBe(500);
+            expect(res.body.error).toBe("Failed to fetch scheduler config");
+        });
+    });
+
+    describe("GET /api/scheduler/logs", () => {
+        it("returns logs for a valid component", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "listNamespacedPod")
+                .resolves({
+                    items: [
+                        {
+                            metadata: { name: "volcano-scheduler-abc" },
+                            status: { phase: "Running" },
+                        },
+                    ],
+                });
+
+            sandbox
+                .stub(CoreV1Api.prototype, "readNamespacedPodLog")
+                .resolves("I0503 scheduler started\n");
+
+            const res = await request(app).get(
+                "/api/scheduler/logs?component=scheduler&tailLines=50",
+            );
+
+            expect(res.status).toBe(200);
+            expect(res.body.component).toBe("scheduler");
+            expect(res.body.pod).toBe("volcano-scheduler-abc");
+            expect(res.body.logs).toContain("scheduler started");
+        });
+
+        it("returns 400 for an unknown component", async () => {
+            const res = await request(app).get(
+                "/api/scheduler/logs?component=unknown-thing",
+            );
+
+            expect(res.status).toBe(400);
+            expect(res.body.error).toMatch(/Unknown component/);
+        });
+
+        it("returns 404 when no running pod is found", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "listNamespacedPod")
+                .resolves({ items: [] });
+
+            const res = await request(app).get("/api/scheduler/logs");
+
+            expect(res.status).toBe(404);
+            expect(res.body.error).toMatch(/No running pod found/);
+        });
     });
 });

--- a/deployment/volcano-dashboard.yaml
+++ b/deployment/volcano-dashboard.yaml
@@ -142,6 +142,21 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      - volcano-scheduler-configmap
+    verbs:
+      - get
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - pods/log
+    verbs:
+      - get
 ---
 
 # volcano dashboard service


### PR DESCRIPTION
## Summary

Part of #197 — adds the backend REST layer for the Scheduler section.

Three new endpoints are added to `backend/src/server.js` following the same Express + `@kubernetes/client-node` pattern used by the rest of the server:

| Method | Path | Description |
|--------|------|-------------|
| `GET`  | `/api/scheduler/config` | Read `volcano-scheduler-configmap` from `volcano-system` |
| `PATCH`| `/api/scheduler/config` | Strategic-merge-patch the same ConfigMap (saves editor changes) |
| `GET`  | `/api/scheduler/logs`   | Tail logs from any Volcano system component |

### `/api/scheduler/logs` query parameters

| Param | Default | Description |
|-------|---------|-------------|
| `component` | `scheduler` | One of `scheduler`, `controller-manager`, `webhook-manager`, `agent` |
| `tailLines` | `100` | Lines from end of log (capped at 5 000) |
| `container` | *(first container)* | Optional container name override |

Pod resolution works by listing pods with the component's label selector (e.g. `app=volcano-scheduler`) and picking the first `Running` pod — consistent with how `kubectl logs -l` behaves.

### RBAC

`deployment/volcano-dashboard.yaml` ClusterRole gains two new rules:
- `configmaps: [get, patch]` scoped to `resourceNames: [volcano-scheduler-configmap]` (least-privilege — only the one ConfigMap the scheduler section needs)
- `pods/log: [get]` under `""` apiGroup

### Tests

`backend/tests/server.test.js` adds 5 new cases:
- Config fetch success and k8s error propagation
- Logs: valid component, unknown component → 400, no running pod → 404

## Test plan
- [ ] `npm test` in `backend/` → all existing and new tests pass
- [ ] With a running cluster: `GET /api/scheduler/config` returns ConfigMap data
- [ ] `GET /api/scheduler/logs?component=scheduler&tailLines=20` returns log lines
- [ ] `GET /api/scheduler/logs?component=unknown` returns 400