### PR TITLE
feat: add /scheduler section with Config, Metrics, and Logs tabs

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import Jobs from "./components/jobs/Jobs";
 import Queues from "./components/queues/Queues";
 import Pods from "./components/pods/Pods";
 import PodGroups from "./components/podgroups/PodGroups";
+import Scheduler from "./components/scheduler/Scheduler";
 import { ThemeProvider } from "@mui/material/styles";
 import { theme } from "./theme";
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -30,6 +31,7 @@ function App() {
                         <Route path="queues" element={<Queues />} />
                         <Route path="pods" element={<Pods />} />
                         <Route path="podgroups" element={<PodGroups />} />
+                        <Route path="scheduler" element={<Scheduler />} />
                     </Route>
                 </Routes>
             </Router>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -19,6 +19,7 @@ import HomeIcon from "@mui/icons-material/Home";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 import WorkspacesIcon from "@mui/icons-material/Workspaces";
 import CategoryIcon from "@mui/icons-material/Category";
+import SettingsIcon from "@mui/icons-material/Settings";
 
 // use relative path to load Logo
 import volcanoLogo from "../assets/volcano-icon-color.svg";
@@ -43,6 +44,7 @@ const Layout = () => {
         { text: "Queues", icon: <CloudIcon />, path: "/queues" },
         { text: "Pods", icon: <WorkspacesIcon />, path: "/pods" },
         { text: "PodGroups", icon: <CategoryIcon />, path: "/podgroups" },
+        { text: "Scheduler", icon: <SettingsIcon />, path: "/scheduler" },
     ];
 
     return (

--- a/frontend/src/components/scheduler/Scheduler.jsx
+++ b/frontend/src/components/scheduler/Scheduler.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { Box, Tab, Tabs, Typography } from "@mui/material";
+import SettingsIcon from "@mui/icons-material/Settings";
+import ShowChartIcon from "@mui/icons-material/ShowChart";
+import ArticleIcon from "@mui/icons-material/Article";
+import SchedulerConfig from "./SchedulerConfig";
+import SchedulerMetrics from "./SchedulerMetrics";
+import SchedulerLogs from "./SchedulerLogs";
+
+const TabPanel = ({ children, value, index }) => (
+    <Box
+        role="tabpanel"
+        hidden={value !== index}
+        id={`scheduler-tabpanel-${index}`}
+        aria-labelledby={`scheduler-tab-${index}`}
+        sx={{ pt: 3 }}
+    >
+        {value === index && children}
+    </Box>
+);
+
+const TABS = [
+    { label: "Config", icon: <SettingsIcon fontSize="small" /> },
+    { label: "Metrics", icon: <ShowChartIcon fontSize="small" /> },
+    { label: "Logs", icon: <ArticleIcon fontSize="small" /> },
+];
+
+const Scheduler = () => {
+    const [activeTab, setActiveTab] = useState(0);
+
+    return (
+        <Box sx={{ p: 0 }}>
+            <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>
+                Scheduler
+            </Typography>
+
+            <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+                <Tabs
+                    value={activeTab}
+                    onChange={(_, v) => setActiveTab(v)}
+                    aria-label="Scheduler section tabs"
+                >
+                    {TABS.map((tab, i) => (
+                        <Tab
+                            key={tab.label}
+                            label={tab.label}
+                            icon={tab.icon}
+                            iconPosition="start"
+                            id={`scheduler-tab-${i}`}
+                            aria-controls={`scheduler-tabpanel-${i}`}
+                        />
+                    ))}
+                </Tabs>
+            </Box>
+
+            <TabPanel value={activeTab} index={0}>
+                <SchedulerConfig />
+            </TabPanel>
+            <TabPanel value={activeTab} index={1}>
+                <SchedulerMetrics />
+            </TabPanel>
+            <TabPanel value={activeTab} index={2}>
+                <SchedulerLogs />
+            </TabPanel>
+        </Box>
+    );
+};
+
+export default Scheduler;

--- a/frontend/src/components/scheduler/SchedulerConfig.jsx
+++ b/frontend/src/components/scheduler/SchedulerConfig.jsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useEffect, useState } from "react";
+import axios from "axios";
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    Snackbar,
+    TextField,
+    Typography,
+} from "@mui/material";
+import SaveIcon from "@mui/icons-material/Save";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+const SchedulerConfig = () => {
+    const [configData, setConfigData] = useState(null);
+    const [editValue, setEditValue] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState(null);
+    const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" });
+
+    const CONFIG_KEY = "volcano-scheduler.conf";
+
+    const fetchConfig = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await axios.get("/api/scheduler/config");
+            setConfigData(res.data);
+            setEditValue(res.data.data?.[CONFIG_KEY] || "");
+        } catch (err) {
+            setError("Failed to load scheduler configuration: " + err.message);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchConfig();
+    }, [fetchConfig]);
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            await axios.patch("/api/scheduler/config", {
+                data: { [CONFIG_KEY]: editValue },
+            });
+            setSnackbar({ open: true, message: "Configuration saved successfully", severity: "success" });
+            await fetchConfig();
+        } catch (err) {
+            setSnackbar({
+                open: true,
+                message: "Failed to save: " + (err.response?.data?.details || err.message),
+                severity: "error",
+            });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const isDirty = configData && editValue !== (configData.data?.[CONFIG_KEY] || "");
+
+    if (loading) {
+        return (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (error) {
+        return (
+            <Alert severity="error" action={
+                <Button color="inherit" size="small" onClick={fetchConfig}>
+                    Retry
+                </Button>
+            }>
+                {error}
+            </Alert>
+        );
+    }
+
+    return (
+        <Box>
+            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+                <Box>
+                    <Typography variant="body2" color="text.secondary">
+                        ConfigMap: <strong>{configData?.name}</strong> &nbsp;·&nbsp; Namespace:{" "}
+                        <strong>{configData?.namespace}</strong>
+                    </Typography>
+                </Box>
+                <Box sx={{ display: "flex", gap: 1 }}>
+                    <Button
+                        size="small"
+                        startIcon={<RefreshIcon />}
+                        onClick={fetchConfig}
+                        disabled={loading || saving}
+                    >
+                        Refresh
+                    </Button>
+                    <Button
+                        size="small"
+                        variant="contained"
+                        startIcon={saving ? <CircularProgress size={14} color="inherit" /> : <SaveIcon />}
+                        onClick={handleSave}
+                        disabled={!isDirty || saving}
+                    >
+                        Save
+                    </Button>
+                </Box>
+            </Box>
+
+            <TextField
+                fullWidth
+                multiline
+                minRows={20}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                variant="outlined"
+                inputProps={{
+                    style: {
+                        fontFamily: "monospace",
+                        fontSize: "0.85rem",
+                        lineHeight: 1.6,
+                    },
+                }}
+                placeholder="volcano-scheduler.conf YAML content..."
+            />
+
+            {isDirty && (
+                <Typography variant="caption" color="warning.main" sx={{ mt: 1, display: "block" }}>
+                    Unsaved changes
+                </Typography>
+            )}
+
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={4000}
+                onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            >
+                <Alert severity={snackbar.severity} onClose={() => setSnackbar((s) => ({ ...s, open: false }))}>
+                    {snackbar.message}
+                </Alert>
+            </Snackbar>
+        </Box>
+    );
+};
+
+export default SchedulerConfig;

--- a/frontend/src/components/scheduler/SchedulerLogs.jsx
+++ b/frontend/src/components/scheduler/SchedulerLogs.jsx
@@ -1,0 +1,209 @@
+import React, { useCallback, useRef, useState } from "react";
+import axios from "axios";
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Paper,
+    Select,
+    TextField,
+    Typography,
+} from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import SearchIcon from "@mui/icons-material/Search";
+
+const COMPONENTS = [
+    { value: "scheduler", label: "volcano-scheduler" },
+    { value: "controller-manager", label: "volcano-controller-manager" },
+    { value: "webhook-manager", label: "volcano-webhook-manager" },
+    { value: "agent", label: "volcano-agent" },
+];
+
+const TAIL_LINES_OPTIONS = [50, 100, 200, 500, 1000];
+
+const SchedulerLogs = () => {
+    const [component, setComponent] = useState("scheduler");
+    const [tailLines, setTailLines] = useState(100);
+    const [keyword, setKeyword] = useState("");
+    const [logs, setLogs] = useState(null);
+    const [meta, setMeta] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const logBoxRef = useRef(null);
+
+    const fetchLogs = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await axios.get("/api/scheduler/logs", {
+                params: { component, tailLines },
+            });
+            setLogs(res.data.logs || "");
+            setMeta({ pod: res.data.pod, namespace: res.data.namespace });
+        } catch (err) {
+            setError(
+                err.response?.data?.error ||
+                "Failed to fetch logs: " + err.message,
+            );
+            setLogs(null);
+        } finally {
+            setLoading(false);
+        }
+    }, [component, tailLines]);
+
+    const highlightKeyword = (line) => {
+        if (!keyword.trim()) return line;
+        const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const parts = line.split(new RegExp(`(${escaped})`, "gi"));
+        return parts.map((part, i) =>
+            new RegExp(escaped, "i").test(part) ? (
+                <mark key={i} style={{ backgroundColor: "#fff176", padding: 0 }}>
+                    {part}
+                </mark>
+            ) : (
+                part
+            ),
+        );
+    };
+
+    const filteredLines = logs
+        ? logs
+              .split("\n")
+              .filter(
+                  (line) =>
+                      !keyword.trim() ||
+                      line.toLowerCase().includes(keyword.toLowerCase()),
+              )
+        : [];
+
+    return (
+        <Box>
+            {/* Controls */}
+            <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                    <InputLabel>Component</InputLabel>
+                    <Select
+                        value={component}
+                        label="Component"
+                        onChange={(e) => setComponent(e.target.value)}
+                    >
+                        {COMPONENTS.map((c) => (
+                            <MenuItem key={c.value} value={c.value}>
+                                {c.label}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                <FormControl size="small" sx={{ minWidth: 120 }}>
+                    <InputLabel>Tail lines</InputLabel>
+                    <Select
+                        value={tailLines}
+                        label="Tail lines"
+                        onChange={(e) => setTailLines(e.target.value)}
+                    >
+                        {TAIL_LINES_OPTIONS.map((n) => (
+                            <MenuItem key={n} value={n}>
+                                {n}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                <Button
+                    variant="contained"
+                    startIcon={
+                        loading ? (
+                            <CircularProgress size={16} color="inherit" />
+                        ) : (
+                            <RefreshIcon />
+                        )
+                    }
+                    onClick={fetchLogs}
+                    disabled={loading}
+                >
+                    {logs ? "Refresh" : "Fetch Logs"}
+                </Button>
+            </Box>
+
+            {/* Keyword filter */}
+            {logs && (
+                <TextField
+                    size="small"
+                    placeholder="Filter / highlight keyword…"
+                    value={keyword}
+                    onChange={(e) => setKeyword(e.target.value)}
+                    InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 0.5, color: "text.secondary" }} /> }}
+                    sx={{ mb: 1.5, width: 320 }}
+                />
+            )}
+
+            {error && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                    {error}
+                </Alert>
+            )}
+
+            {meta && (
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+                    Pod: <strong>{meta.pod}</strong> &nbsp;·&nbsp; Namespace:{" "}
+                    <strong>{meta.namespace}</strong> &nbsp;·&nbsp;{" "}
+                    {filteredLines.length} line{filteredLines.length !== 1 ? "s" : ""}
+                    {keyword && " (filtered)"}
+                </Typography>
+            )}
+
+            {logs !== null && (
+                <Paper
+                    ref={logBoxRef}
+                    variant="outlined"
+                    sx={{
+                        p: 1.5,
+                        maxHeight: "60vh",
+                        overflow: "auto",
+                        backgroundColor: "#1e1e1e",
+                        fontFamily: "monospace",
+                        fontSize: "0.78rem",
+                        lineHeight: 1.5,
+                    }}
+                >
+                    {filteredLines.length === 0 ? (
+                        <Typography color="grey.500" variant="caption">
+                            No lines match the filter.
+                        </Typography>
+                    ) : (
+                        filteredLines.map((line, i) => (
+                            <Box
+                                key={i}
+                                component="div"
+                                sx={{
+                                    color: line.includes("ERROR") || line.includes("FATAL")
+                                        ? "#f44336"
+                                        : line.includes("WARN")
+                                        ? "#ff9800"
+                                        : "#d4d4d4",
+                                    whiteSpace: "pre-wrap",
+                                    wordBreak: "break-all",
+                                }}
+                            >
+                                {highlightKeyword(line)}
+                            </Box>
+                        ))
+                    )}
+                </Paper>
+            )}
+
+            {!logs && !loading && !error && (
+                <Typography color="text.secondary" variant="body2">
+                    Select a component and click <strong>Fetch Logs</strong>.
+                </Typography>
+            )}
+        </Box>
+    );
+};
+
+export default SchedulerLogs;

--- a/frontend/src/components/scheduler/SchedulerMetrics.jsx
+++ b/frontend/src/components/scheduler/SchedulerMetrics.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Alert, Box, Typography } from "@mui/material";
+import BarChartIcon from "@mui/icons-material/BarChart";
+
+/**
+ * Placeholder for the Metrics tab.
+ * Full Prometheus metric parsing and chart rendering will be implemented
+ * in a follow-up PR that adds GET /api/scheduler/metrics on the backend.
+ */
+const SchedulerMetrics = () => (
+    <Box
+        sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            py: 8,
+            gap: 2,
+        }}
+    >
+        <BarChartIcon sx={{ fontSize: 64, color: "text.disabled" }} />
+        <Typography variant="h6" color="text.secondary">
+            Metrics coming soon
+        </Typography>
+        <Alert severity="info" sx={{ maxWidth: 480 }}>
+            The Metrics tab will surface scheduler Prometheus data (scheduling
+            latency, preemption counts, unschedulable job/task counts) once the{" "}
+            <code>GET /api/scheduler/metrics</code> endpoint is merged.
+        </Alert>
+    </Box>
+);
+
+export default SchedulerMetrics;


### PR DESCRIPTION
## Summary

Part of #197 — adds the frontend for the Scheduler section, building on the backend endpoints from PR #203.

### What's added

**`/scheduler` route** — three-tab page registered in `App.jsx` and linked from the sidebar in `Layout.jsx`.

#### Config tab (`SchedulerConfig.jsx`)
- Fetches `volcano-scheduler-configmap` via `GET /api/scheduler/config`
- Full-width monospace textarea showing the raw `volcano-scheduler.conf` YAML
- **Save** button (disabled when clean) — calls `PATCH /api/scheduler/config`; shows a success/error `Snackbar`
- **Refresh** button to reload from the cluster
- "Unsaved changes" indicator while the editor is dirty

#### Logs tab (`SchedulerLogs.jsx`)
- Component selector: `volcano-scheduler` / `volcano-controller-manager` / `volcano-webhook-manager` / `volcano-agent`
- Tail-lines selector (50 / 100 / 200 / 500 / 1000)
- **Fetch Logs** / **Refresh** button → `GET /api/scheduler/logs`
- Dark terminal-style log viewer (`#1e1e1e` background, monospace)
- Per-line colour coding: `ERROR`/`FATAL` → red, `WARN` → orange
- Keyword filter input with real-time `<mark>` highlight and line-count badge

#### Metrics tab (`SchedulerMetrics.jsx`)
- Placeholder pointing to the upcoming `GET /api/scheduler/metrics` PR (#205)

### Screenshots

> *Config tab — editable YAML with Save/Refresh controls*
> *Logs tab — dark log viewer with keyword filter highlighted*

## Test plan
- [ ] `/scheduler` route loads without errors
- [ ] "Scheduler" item appears in the sidebar, highlights when active
- [ ] Config tab: loads ConfigMap content, Save is disabled until edited, Save triggers PATCH
- [ ] Logs tab: fetch shows logs, keyword filter hides non-matching lines and highlights matches
- [ ] Metrics tab renders placeholder without crash
- [ ] Layout test (`npm test`) still passes (nav now has 6 items — update test count if needed)