### PR TITLE
feat: add scheduler Prometheus metrics endpoint and Metrics tab charts

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -984,6 +984,400 @@ app.delete("/api/queues/:name", async (req, res) => {
     }
 });
 
+// ─── Scheduler API ────────────────────────────────────────────────────────────
+
+const VOLCANO_NAMESPACE = "volcano-system";
+const SCHEDULER_CONFIGMAP = "volcano-scheduler-configmap";
+
+// Component → label selector used to locate the right pod
+const COMPONENT_LABELS = {
+    scheduler: "app=volcano-scheduler",
+    "controller-manager": "app=volcano-controller-manager",
+    "webhook-manager": "app=volcano-webhook-manager",
+    agent: "app=volcano-agent",
+};
+
+/**
+ * Resolve the running pod name for a Volcano component.
+ * Returns the first Running pod matching the component's label selector,
+ * or null when no matching pod is found.
+ */
+async function resolveComponentPod(component) {
+    const labelSelector =
+        COMPONENT_LABELS[component] ||
+        `app=volcano-${component}`;
+
+    const response = await k8sCoreApi.listNamespacedPod({
+        namespace: VOLCANO_NAMESPACE,
+        labelSelector,
+    });
+
+    const pods = (response.items || []).filter(
+        (p) => p.status?.phase === "Running",
+    );
+
+    return pods.length > 0 ? pods[0].metadata.name : null;
+}
+
+// GET /api/scheduler/config
+// Returns the volcano-scheduler-configmap data as JSON.
+app.get("/api/scheduler/config", async (req, res) => {
+    try {
+        const cm = await k8sCoreApi.readNamespacedConfigMap({
+            name: SCHEDULER_CONFIGMAP,
+            namespace: VOLCANO_NAMESPACE,
+        });
+        res.json({
+            name: cm.metadata.name,
+            namespace: cm.metadata.namespace,
+            resourceVersion: cm.metadata.resourceVersion,
+            data: cm.data || {},
+        });
+    } catch (err) {
+        console.error("Error fetching scheduler config:", err);
+        res.status(500).json({
+            error: "Failed to fetch scheduler config",
+            details: err.message,
+        });
+    }
+});
+
+// PATCH /api/scheduler/config
+// Applies a strategic-merge patch to the volcano-scheduler-configmap.
+// Body: { data: { "volcano-scheduler.conf": "<yaml string>" } }
+app.patch("/api/scheduler/config", async (req, res) => {
+    try {
+        const patchBody = req.body;
+
+        if (!patchBody || typeof patchBody !== "object") {
+            return res.status(400).json({ error: "Request body must be a JSON object" });
+        }
+
+        const response = await k8sCoreApi.patchNamespacedConfigMap({
+            name: SCHEDULER_CONFIGMAP,
+            namespace: VOLCANO_NAMESPACE,
+            body: patchBody,
+            options: {
+                headers: { "Content-Type": "application/merge-patch+json" },
+            },
+        });
+
+        res.json({
+            message: "Scheduler config updated successfully",
+            resourceVersion: response.metadata?.resourceVersion,
+        });
+    } catch (err) {
+        console.error("Error patching scheduler config:", err);
+        res.status(500).json({
+            error: "Failed to update scheduler config",
+            details: err?.body?.message || err.message,
+        });
+    }
+});
+
+// GET /api/scheduler/logs
+// Query params:
+//   component  — scheduler | controller-manager | webhook-manager | agent  (default: scheduler)
+//   tailLines  — number of lines to return from the end of the log (default: 100)
+//   container  — optional container name (defaults to first container)
+app.get("/api/scheduler/logs", async (req, res) => {
+    try {
+        const component = req.query.component || "scheduler";
+        const tailLines = Math.min(
+            parseInt(req.query.tailLines) || 100,
+            5000,
+        );
+
+        if (!COMPONENT_LABELS[component]) {
+            return res.status(400).json({
+                error: `Unknown component '${component}'. Valid values: ${Object.keys(COMPONENT_LABELS).join(", ")}`,
+            });
+        }
+
+        const podName = await resolveComponentPod(component);
+
+        if (!podName) {
+            return res.status(404).json({
+                error: `No running pod found for component '${component}' in namespace '${VOLCANO_NAMESPACE}'`,
+            });
+        }
+
+        const logParams = {
+            name: podName,
+            namespace: VOLCANO_NAMESPACE,
+            tailLines,
+            timestamps: true,
+        };
+
+        if (req.query.container) {
+            logParams.container = req.query.container;
+        }
+
+        const logs = await k8sCoreApi.readNamespacedPodLog(logParams);
+
+        res.json({
+            component,
+            pod: podName,
+            namespace: VOLCANO_NAMESPACE,
+            tailLines,
+            logs: typeof logs === "string" ? logs : String(logs),
+        });
+    } catch (err) {
+        console.error("Error fetching scheduler logs:", err);
+        res.status(500).json({
+            error: "Failed to fetch scheduler logs",
+            details: err?.body?.message || err.message,
+        });
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─── Scheduler Metrics ────────────────────────────────────────────────────────
+
+/**
+ * Parse a Prometheus text-format response into a flat map of
+ * { metricName: value } for scalar gauges/counters and
+ * { metricName: [ { labels, value } ] } for labelled series.
+ *
+ * Only lines that are not comments and not empty are parsed.
+ */
+function parsePrometheusText(text) {
+    const result = {};
+    if (!text) return result;
+
+    for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+
+        // volcano_task_scheduling_latency_milliseconds{action="allocate"} 42.3
+        const match = trimmed.match(/^([^\s{]+)(\{[^}]*\})?\s+([\d.e+\-NaInf]+)/);
+        if (!match) continue;
+
+        const [, name, labelStr, rawValue] = match;
+        const value = parseFloat(rawValue);
+        if (isNaN(value)) continue;
+
+        if (labelStr) {
+            const labels = {};
+            for (const kv of labelStr.slice(1, -1).split(",")) {
+                const eq = kv.indexOf("=");
+                if (eq === -1) continue;
+                labels[kv.slice(0, eq).trim()] = kv
+                    .slice(eq + 1)
+                    .trim()
+                    .replace(/^"|"$/g, "");
+            }
+            if (!result[name]) result[name] = [];
+            result[name].push({ labels, value });
+        } else {
+            result[name] = value;
+        }
+    }
+    return result;
+}
+
+/**
+ * Aggregate raw parsed Prometheus data into the structured object the
+ * frontend consumes.  Returns null on any error so callers can surface
+ * a clear error message.
+ */
+function aggregateSchedulerMetrics(raw) {
+    const get = (name) => {
+        const v = raw[name];
+        return typeof v === "number" ? v : null;
+    };
+
+    const series = (name) => (Array.isArray(raw[name]) ? raw[name] : []);
+
+    // Unschedulable counts
+    const unschedulableJobs = get("volcano_queue_unschedulable_task_count");
+    const unschedulableTasks = get("volcano_task_unschedulable_count");
+
+    // Preemption
+    const preemptionVictims = get("volcano_preemption_victims");
+    const preemptionAttempts = get("volcano_preemption_attempts_total");
+
+    // E2E and per-action scheduling latency
+    const e2eLatency = series("volcano_e2e_scheduling_latency_milliseconds");
+    const actionLatency = series("volcano_task_scheduling_latency_milliseconds");
+
+    // Per-plugin latency (if exposed)
+    const pluginLatency = series("volcano_plugin_scheduling_latency_milliseconds");
+
+    return {
+        statCards: {
+            unschedulableJobs,
+            unschedulableTasks,
+            preemptionVictims,
+            preemptionAttempts,
+        },
+        charts: {
+            e2eLatency,
+            actionLatency,
+            pluginLatency,
+        },
+    };
+}
+
+// GET /api/scheduler/metrics
+// Proxies the Prometheus /metrics endpoint of the running scheduler pod
+// and returns a structured JSON object ready for frontend charts.
+app.get("/api/scheduler/metrics", async (req, res) => {
+    try {
+        // Resolve the scheduler pod
+        const podName = await resolveComponentPod("scheduler");
+
+        if (!podName) {
+            return res.status(404).json({
+                error: "No running volcano-scheduler pod found in volcano-system",
+            });
+        }
+
+        // Use the Kubernetes API proxy to reach the scheduler's /metrics endpoint
+        // (port 8080 is the default metrics port for volcano-scheduler)
+        const metricsPort = parseInt(req.query.port) || 8080;
+        const metricsPath = req.query.path || "/metrics";
+
+        // Build the proxy URL via the k8s API server
+        // kc is the KubeConfig used throughout server.js
+        const proxyUrl = `/api/v1/namespaces/${VOLCANO_NAMESPACE}/pods/${podName}:${metricsPort}/proxy${metricsPath}`;
+
+        // Use the raw k8s API request mechanism to proxy through the API server
+        const response = await k8sCoreApi.connectGetNamespacedPodProxyWithPath({
+            name: `${podName}:${metricsPort}`,
+            namespace: VOLCANO_NAMESPACE,
+            path: metricsPath.replace(/^\//, ""),
+        }).catch(async () => {
+            // Fallback: try without port in the pod name
+            return k8sCoreApi.connectGetNamespacedPodProxyWithPath({
+                name: podName,
+                namespace: VOLCANO_NAMESPACE,
+                path: metricsPath.replace(/^\//, ""),
+            });
+        });
+
+        const rawText = typeof response === "string" ? response : JSON.stringify(response);
+        const parsed = parsePrometheusText(rawText);
+        const metrics = aggregateSchedulerMetrics(parsed);
+
+        res.json({ pod: podName, namespace: VOLCANO_NAMESPACE, metrics });
+    } catch (err) {
+        console.error("Error fetching scheduler metrics:", err);
+        res.status(500).json({
+            error: "Failed to fetch scheduler metrics",
+            details: err?.body?.message || err.message,
+        });
+    }
+});
+
+// ─── Scheduler Metrics ────────────────────────────────────────────────────────
+
+/**
+ * Parse a Prometheus text-format response into a flat map of
+ * { metricName: number } for scalar series and
+ * { metricName: [ { labels, value } ] } for labelled series.
+ */
+function parsePrometheusText(text) {
+    const result = {};
+    if (!text) return result;
+
+    for (const line of text.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed.startsWith("#")) continue;
+
+        const match = trimmed.match(/^([^\s{]+)(\{[^}]*\})?\s+([\d.e+\-NaInf]+)/);
+        if (!match) continue;
+
+        const [, name, labelStr, rawValue] = match;
+        const value = parseFloat(rawValue);
+        if (isNaN(value)) continue;
+
+        if (labelStr) {
+            const labels = {};
+            for (const kv of labelStr.slice(1, -1).split(",")) {
+                const eq = kv.indexOf("=");
+                if (eq === -1) continue;
+                labels[kv.slice(0, eq).trim()] = kv
+                    .slice(eq + 1)
+                    .trim()
+                    .replace(/^"|"$/g, "");
+            }
+            if (!result[name]) result[name] = [];
+            result[name].push({ labels, value });
+        } else {
+            result[name] = value;
+        }
+    }
+    return result;
+}
+
+function aggregateSchedulerMetrics(raw) {
+    const scalar = (name) => (typeof raw[name] === "number" ? raw[name] : null);
+    const series = (name) => (Array.isArray(raw[name]) ? raw[name] : []);
+
+    return {
+        statCards: {
+            unschedulableJobs: scalar("volcano_queue_unschedulable_task_count"),
+            unschedulableTasks: scalar("volcano_task_unschedulable_count"),
+            preemptionVictims: scalar("volcano_preemption_victims"),
+            preemptionAttempts: scalar("volcano_preemption_attempts_total"),
+        },
+        charts: {
+            e2eLatency: series("volcano_e2e_scheduling_latency_milliseconds"),
+            actionLatency: series("volcano_task_scheduling_latency_milliseconds"),
+            pluginLatency: series("volcano_plugin_scheduling_latency_milliseconds"),
+        },
+    };
+}
+
+// GET /api/scheduler/metrics
+// Proxies the Prometheus /metrics endpoint of the running scheduler pod through
+// the Kubernetes API server and returns a structured JSON object.
+app.get("/api/scheduler/metrics", async (req, res) => {
+    try {
+        const podName = await resolveComponentPod("scheduler");
+
+        if (!podName) {
+            return res.status(404).json({
+                error: "No running volcano-scheduler pod found in volcano-system",
+            });
+        }
+
+        const metricsPort = parseInt(req.query.port) || 8080;
+        const metricsPath = req.query.path || "metrics";
+
+        let rawText;
+        try {
+            rawText = await k8sCoreApi.connectGetNamespacedPodProxyWithPath({
+                name: `${podName}:${metricsPort}`,
+                namespace: VOLCANO_NAMESPACE,
+                path: metricsPath,
+            });
+        } catch {
+            rawText = await k8sCoreApi.connectGetNamespacedPodProxyWithPath({
+                name: podName,
+                namespace: VOLCANO_NAMESPACE,
+                path: metricsPath,
+            });
+        }
+
+        const text = typeof rawText === "string" ? rawText : JSON.stringify(rawText);
+        const parsed = parsePrometheusText(text);
+        const metrics = aggregateSchedulerMetrics(parsed);
+
+        res.json({ pod: podName, namespace: VOLCANO_NAMESPACE, metrics });
+    } catch (err) {
+        console.error("Error fetching scheduler metrics:", err);
+        res.status(500).json({
+            error: "Failed to fetch scheduler metrics",
+            details: err?.body?.message || err.message,
+        });
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+
 const verifyVolcanoSetup = async () => {
     try {
         // Verify CRD access

--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -1,7 +1,10 @@
 import sinon from "sinon";
 import request from "supertest";
 import { app } from "../src/server.js";
-import { CustomObjectsApi } from "@kubernetes/client-node";
+import { CustomObjectsApi, CoreV1Api } from "@kubernetes/client-node";
+
+// Re-export the private parser for unit-testing via a named export trick.
+// The parser is tested indirectly through the /api/scheduler/metrics endpoint.
 
 describe("backend", () => {
     let sandbox;
@@ -77,5 +80,140 @@ describe("backend", () => {
         expect(res.status).toBe(200);
         expect(res.body.items).toHaveLength(2);
         expect(res.body.items[0].metadata.name).toBe("pg1");
+    });
+
+    describe("GET /api/scheduler/config", () => {
+        it("returns configmap data on success", async () => {
+            const mockCM = {
+                metadata: {
+                    name: "volcano-scheduler-configmap",
+                    namespace: "volcano-system",
+                    resourceVersion: "12345",
+                },
+                data: {
+                    "volcano-scheduler.conf":
+                        "actions: \"enqueue, allocate\"\nplugins:\n",
+                },
+            };
+
+            sandbox
+                .stub(CoreV1Api.prototype, "readNamespacedConfigMap")
+                .resolves(mockCM);
+
+            const res = await request(app).get("/api/scheduler/config");
+
+            expect(res.status).toBe(200);
+            expect(res.body.name).toBe("volcano-scheduler-configmap");
+            expect(res.body.data).toHaveProperty("volcano-scheduler.conf");
+        });
+
+        it("returns 500 when the k8s call fails", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "readNamespacedConfigMap")
+                .rejects(new Error("forbidden"));
+
+            const res = await request(app).get("/api/scheduler/config");
+
+            expect(res.status).toBe(500);
+            expect(res.body.error).toBe("Failed to fetch scheduler config");
+        });
+    });
+
+    describe("GET /api/scheduler/logs", () => {
+        it("returns logs for a valid component", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "listNamespacedPod")
+                .resolves({
+                    items: [
+                        {
+                            metadata: { name: "volcano-scheduler-abc" },
+                            status: { phase: "Running" },
+                        },
+                    ],
+                });
+
+            sandbox
+                .stub(CoreV1Api.prototype, "readNamespacedPodLog")
+                .resolves("I0503 scheduler started\n");
+
+            const res = await request(app).get(
+                "/api/scheduler/logs?component=scheduler&tailLines=50",
+            );
+
+            expect(res.status).toBe(200);
+            expect(res.body.component).toBe("scheduler");
+            expect(res.body.pod).toBe("volcano-scheduler-abc");
+            expect(res.body.logs).toContain("scheduler started");
+        });
+
+        it("returns 400 for an unknown component", async () => {
+            const res = await request(app).get(
+                "/api/scheduler/logs?component=unknown-thing",
+            );
+
+            expect(res.status).toBe(400);
+            expect(res.body.error).toMatch(/Unknown component/);
+        });
+
+        it("returns 404 when no running pod is found", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "listNamespacedPod")
+                .resolves({ items: [] });
+
+            const res = await request(app).get("/api/scheduler/logs");
+
+            expect(res.status).toBe(404);
+            expect(res.body.error).toMatch(/No running pod found/);
+        });
+    });
+
+    describe("GET /api/scheduler/metrics", () => {
+        const PROMETHEUS_STUB = `
+# HELP volcano_queue_unschedulable_task_count Number of unschedulable tasks
+# TYPE volcano_queue_unschedulable_task_count gauge
+volcano_queue_unschedulable_task_count 3
+# HELP volcano_preemption_victims Number of preemption victims
+# TYPE volcano_preemption_victims gauge
+volcano_preemption_victims 1
+# HELP volcano_task_scheduling_latency_milliseconds Scheduling latency per action
+# TYPE volcano_task_scheduling_latency_milliseconds gauge
+volcano_task_scheduling_latency_milliseconds{action="allocate"} 42.5
+volcano_task_scheduling_latency_milliseconds{action="backfill"} 18.2
+`.trim();
+
+        it("returns structured metrics when proxy succeeds", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "listNamespacedPod")
+                .resolves({
+                    items: [
+                        {
+                            metadata: { name: "volcano-scheduler-xyz" },
+                            status: { phase: "Running" },
+                        },
+                    ],
+                });
+
+            sandbox
+                .stub(CoreV1Api.prototype, "connectGetNamespacedPodProxyWithPath")
+                .resolves(PROMETHEUS_STUB);
+
+            const res = await request(app).get("/api/scheduler/metrics");
+
+            expect(res.status).toBe(200);
+            expect(res.body.pod).toBe("volcano-scheduler-xyz");
+            expect(res.body.metrics.statCards.unschedulableJobs).toBe(3);
+            expect(res.body.metrics.statCards.preemptionVictims).toBe(1);
+            expect(res.body.metrics.charts.actionLatency).toHaveLength(2);
+        });
+
+        it("returns 404 when no scheduler pod is running", async () => {
+            sandbox
+                .stub(CoreV1Api.prototype, "listNamespacedPod")
+                .resolves({ items: [] });
+
+            const res = await request(app).get("/api/scheduler/metrics");
+
+            expect(res.status).toBe(404);
+        });
     });
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -11,6 +11,7 @@ import Jobs from "./components/jobs/Jobs";
 import Queues from "./components/queues/Queues";
 import Pods from "./components/pods/Pods";
 import PodGroups from "./components/podgroups/PodGroups";
+import Scheduler from "./components/scheduler/Scheduler";
 import { ThemeProvider } from "@mui/material/styles";
 import { theme } from "./theme";
 import "bootstrap/dist/css/bootstrap.min.css";
@@ -30,6 +31,7 @@ function App() {
                         <Route path="queues" element={<Queues />} />
                         <Route path="pods" element={<Pods />} />
                         <Route path="podgroups" element={<PodGroups />} />
+                        <Route path="scheduler" element={<Scheduler />} />
                     </Route>
                 </Routes>
             </Router>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -19,6 +19,7 @@ import HomeIcon from "@mui/icons-material/Home";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 import WorkspacesIcon from "@mui/icons-material/Workspaces";
 import CategoryIcon from "@mui/icons-material/Category";
+import SettingsIcon from "@mui/icons-material/Settings";
 
 // use relative path to load Logo
 import volcanoLogo from "../assets/volcano-icon-color.svg";
@@ -43,6 +44,7 @@ const Layout = () => {
         { text: "Queues", icon: <CloudIcon />, path: "/queues" },
         { text: "Pods", icon: <WorkspacesIcon />, path: "/pods" },
         { text: "PodGroups", icon: <CategoryIcon />, path: "/podgroups" },
+        { text: "Scheduler", icon: <SettingsIcon />, path: "/scheduler" },
     ];
 
     return (

--- a/frontend/src/components/scheduler/Scheduler.jsx
+++ b/frontend/src/components/scheduler/Scheduler.jsx
@@ -1,0 +1,69 @@
+import React, { useState } from "react";
+import { Box, Tab, Tabs, Typography } from "@mui/material";
+import SettingsIcon from "@mui/icons-material/Settings";
+import ShowChartIcon from "@mui/icons-material/ShowChart";
+import ArticleIcon from "@mui/icons-material/Article";
+import SchedulerConfig from "./SchedulerConfig";
+import SchedulerMetrics from "./SchedulerMetrics";
+import SchedulerLogs from "./SchedulerLogs";
+
+const TabPanel = ({ children, value, index }) => (
+    <Box
+        role="tabpanel"
+        hidden={value !== index}
+        id={`scheduler-tabpanel-${index}`}
+        aria-labelledby={`scheduler-tab-${index}`}
+        sx={{ pt: 3 }}
+    >
+        {value === index && children}
+    </Box>
+);
+
+const TABS = [
+    { label: "Config", icon: <SettingsIcon fontSize="small" /> },
+    { label: "Metrics", icon: <ShowChartIcon fontSize="small" /> },
+    { label: "Logs", icon: <ArticleIcon fontSize="small" /> },
+];
+
+const Scheduler = () => {
+    const [activeTab, setActiveTab] = useState(0);
+
+    return (
+        <Box sx={{ p: 0 }}>
+            <Typography variant="h5" fontWeight={600} sx={{ mb: 2 }}>
+                Scheduler
+            </Typography>
+
+            <Box sx={{ borderBottom: 1, borderColor: "divider" }}>
+                <Tabs
+                    value={activeTab}
+                    onChange={(_, v) => setActiveTab(v)}
+                    aria-label="Scheduler section tabs"
+                >
+                    {TABS.map((tab, i) => (
+                        <Tab
+                            key={tab.label}
+                            label={tab.label}
+                            icon={tab.icon}
+                            iconPosition="start"
+                            id={`scheduler-tab-${i}`}
+                            aria-controls={`scheduler-tabpanel-${i}`}
+                        />
+                    ))}
+                </Tabs>
+            </Box>
+
+            <TabPanel value={activeTab} index={0}>
+                <SchedulerConfig />
+            </TabPanel>
+            <TabPanel value={activeTab} index={1}>
+                <SchedulerMetrics />
+            </TabPanel>
+            <TabPanel value={activeTab} index={2}>
+                <SchedulerLogs />
+            </TabPanel>
+        </Box>
+    );
+};
+
+export default Scheduler;

--- a/frontend/src/components/scheduler/SchedulerConfig.jsx
+++ b/frontend/src/components/scheduler/SchedulerConfig.jsx
@@ -1,0 +1,151 @@
+import React, { useCallback, useEffect, useState } from "react";
+import axios from "axios";
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    Snackbar,
+    TextField,
+    Typography,
+} from "@mui/material";
+import SaveIcon from "@mui/icons-material/Save";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+const SchedulerConfig = () => {
+    const [configData, setConfigData] = useState(null);
+    const [editValue, setEditValue] = useState("");
+    const [loading, setLoading] = useState(false);
+    const [saving, setSaving] = useState(false);
+    const [error, setError] = useState(null);
+    const [snackbar, setSnackbar] = useState({ open: false, message: "", severity: "success" });
+
+    const CONFIG_KEY = "volcano-scheduler.conf";
+
+    const fetchConfig = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await axios.get("/api/scheduler/config");
+            setConfigData(res.data);
+            setEditValue(res.data.data?.[CONFIG_KEY] || "");
+        } catch (err) {
+            setError("Failed to load scheduler configuration: " + err.message);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchConfig();
+    }, [fetchConfig]);
+
+    const handleSave = async () => {
+        setSaving(true);
+        try {
+            await axios.patch("/api/scheduler/config", {
+                data: { [CONFIG_KEY]: editValue },
+            });
+            setSnackbar({ open: true, message: "Configuration saved successfully", severity: "success" });
+            await fetchConfig();
+        } catch (err) {
+            setSnackbar({
+                open: true,
+                message: "Failed to save: " + (err.response?.data?.details || err.message),
+                severity: "error",
+            });
+        } finally {
+            setSaving(false);
+        }
+    };
+
+    const isDirty = configData && editValue !== (configData.data?.[CONFIG_KEY] || "");
+
+    if (loading) {
+        return (
+            <Box sx={{ display: "flex", justifyContent: "center", py: 6 }}>
+                <CircularProgress />
+            </Box>
+        );
+    }
+
+    if (error) {
+        return (
+            <Alert severity="error" action={
+                <Button color="inherit" size="small" onClick={fetchConfig}>
+                    Retry
+                </Button>
+            }>
+                {error}
+            </Alert>
+        );
+    }
+
+    return (
+        <Box>
+            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 2 }}>
+                <Box>
+                    <Typography variant="body2" color="text.secondary">
+                        ConfigMap: <strong>{configData?.name}</strong> &nbsp;·&nbsp; Namespace:{" "}
+                        <strong>{configData?.namespace}</strong>
+                    </Typography>
+                </Box>
+                <Box sx={{ display: "flex", gap: 1 }}>
+                    <Button
+                        size="small"
+                        startIcon={<RefreshIcon />}
+                        onClick={fetchConfig}
+                        disabled={loading || saving}
+                    >
+                        Refresh
+                    </Button>
+                    <Button
+                        size="small"
+                        variant="contained"
+                        startIcon={saving ? <CircularProgress size={14} color="inherit" /> : <SaveIcon />}
+                        onClick={handleSave}
+                        disabled={!isDirty || saving}
+                    >
+                        Save
+                    </Button>
+                </Box>
+            </Box>
+
+            <TextField
+                fullWidth
+                multiline
+                minRows={20}
+                value={editValue}
+                onChange={(e) => setEditValue(e.target.value)}
+                variant="outlined"
+                inputProps={{
+                    style: {
+                        fontFamily: "monospace",
+                        fontSize: "0.85rem",
+                        lineHeight: 1.6,
+                    },
+                }}
+                placeholder="volcano-scheduler.conf YAML content..."
+            />
+
+            {isDirty && (
+                <Typography variant="caption" color="warning.main" sx={{ mt: 1, display: "block" }}>
+                    Unsaved changes
+                </Typography>
+            )}
+
+            <Snackbar
+                open={snackbar.open}
+                autoHideDuration={4000}
+                onClose={() => setSnackbar((s) => ({ ...s, open: false }))}
+                anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+            >
+                <Alert severity={snackbar.severity} onClose={() => setSnackbar((s) => ({ ...s, open: false }))}>
+                    {snackbar.message}
+                </Alert>
+            </Snackbar>
+        </Box>
+    );
+};
+
+export default SchedulerConfig;

--- a/frontend/src/components/scheduler/SchedulerLogs.jsx
+++ b/frontend/src/components/scheduler/SchedulerLogs.jsx
@@ -1,0 +1,209 @@
+import React, { useCallback, useRef, useState } from "react";
+import axios from "axios";
+import {
+    Alert,
+    Box,
+    Button,
+    CircularProgress,
+    FormControl,
+    InputLabel,
+    MenuItem,
+    Paper,
+    Select,
+    TextField,
+    Typography,
+} from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import SearchIcon from "@mui/icons-material/Search";
+
+const COMPONENTS = [
+    { value: "scheduler", label: "volcano-scheduler" },
+    { value: "controller-manager", label: "volcano-controller-manager" },
+    { value: "webhook-manager", label: "volcano-webhook-manager" },
+    { value: "agent", label: "volcano-agent" },
+];
+
+const TAIL_LINES_OPTIONS = [50, 100, 200, 500, 1000];
+
+const SchedulerLogs = () => {
+    const [component, setComponent] = useState("scheduler");
+    const [tailLines, setTailLines] = useState(100);
+    const [keyword, setKeyword] = useState("");
+    const [logs, setLogs] = useState(null);
+    const [meta, setMeta] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const logBoxRef = useRef(null);
+
+    const fetchLogs = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await axios.get("/api/scheduler/logs", {
+                params: { component, tailLines },
+            });
+            setLogs(res.data.logs || "");
+            setMeta({ pod: res.data.pod, namespace: res.data.namespace });
+        } catch (err) {
+            setError(
+                err.response?.data?.error ||
+                "Failed to fetch logs: " + err.message,
+            );
+            setLogs(null);
+        } finally {
+            setLoading(false);
+        }
+    }, [component, tailLines]);
+
+    const highlightKeyword = (line) => {
+        if (!keyword.trim()) return line;
+        const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const parts = line.split(new RegExp(`(${escaped})`, "gi"));
+        return parts.map((part, i) =>
+            new RegExp(escaped, "i").test(part) ? (
+                <mark key={i} style={{ backgroundColor: "#fff176", padding: 0 }}>
+                    {part}
+                </mark>
+            ) : (
+                part
+            ),
+        );
+    };
+
+    const filteredLines = logs
+        ? logs
+              .split("\n")
+              .filter(
+                  (line) =>
+                      !keyword.trim() ||
+                      line.toLowerCase().includes(keyword.toLowerCase()),
+              )
+        : [];
+
+    return (
+        <Box>
+            {/* Controls */}
+            <Box sx={{ display: "flex", gap: 2, flexWrap: "wrap", mb: 2 }}>
+                <FormControl size="small" sx={{ minWidth: 220 }}>
+                    <InputLabel>Component</InputLabel>
+                    <Select
+                        value={component}
+                        label="Component"
+                        onChange={(e) => setComponent(e.target.value)}
+                    >
+                        {COMPONENTS.map((c) => (
+                            <MenuItem key={c.value} value={c.value}>
+                                {c.label}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                <FormControl size="small" sx={{ minWidth: 120 }}>
+                    <InputLabel>Tail lines</InputLabel>
+                    <Select
+                        value={tailLines}
+                        label="Tail lines"
+                        onChange={(e) => setTailLines(e.target.value)}
+                    >
+                        {TAIL_LINES_OPTIONS.map((n) => (
+                            <MenuItem key={n} value={n}>
+                                {n}
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+
+                <Button
+                    variant="contained"
+                    startIcon={
+                        loading ? (
+                            <CircularProgress size={16} color="inherit" />
+                        ) : (
+                            <RefreshIcon />
+                        )
+                    }
+                    onClick={fetchLogs}
+                    disabled={loading}
+                >
+                    {logs ? "Refresh" : "Fetch Logs"}
+                </Button>
+            </Box>
+
+            {/* Keyword filter */}
+            {logs && (
+                <TextField
+                    size="small"
+                    placeholder="Filter / highlight keyword…"
+                    value={keyword}
+                    onChange={(e) => setKeyword(e.target.value)}
+                    InputProps={{ startAdornment: <SearchIcon fontSize="small" sx={{ mr: 0.5, color: "text.secondary" }} /> }}
+                    sx={{ mb: 1.5, width: 320 }}
+                />
+            )}
+
+            {error && (
+                <Alert severity="error" sx={{ mb: 2 }}>
+                    {error}
+                </Alert>
+            )}
+
+            {meta && (
+                <Typography variant="caption" color="text.secondary" sx={{ mb: 1, display: "block" }}>
+                    Pod: <strong>{meta.pod}</strong> &nbsp;·&nbsp; Namespace:{" "}
+                    <strong>{meta.namespace}</strong> &nbsp;·&nbsp;{" "}
+                    {filteredLines.length} line{filteredLines.length !== 1 ? "s" : ""}
+                    {keyword && " (filtered)"}
+                </Typography>
+            )}
+
+            {logs !== null && (
+                <Paper
+                    ref={logBoxRef}
+                    variant="outlined"
+                    sx={{
+                        p: 1.5,
+                        maxHeight: "60vh",
+                        overflow: "auto",
+                        backgroundColor: "#1e1e1e",
+                        fontFamily: "monospace",
+                        fontSize: "0.78rem",
+                        lineHeight: 1.5,
+                    }}
+                >
+                    {filteredLines.length === 0 ? (
+                        <Typography color="grey.500" variant="caption">
+                            No lines match the filter.
+                        </Typography>
+                    ) : (
+                        filteredLines.map((line, i) => (
+                            <Box
+                                key={i}
+                                component="div"
+                                sx={{
+                                    color: line.includes("ERROR") || line.includes("FATAL")
+                                        ? "#f44336"
+                                        : line.includes("WARN")
+                                        ? "#ff9800"
+                                        : "#d4d4d4",
+                                    whiteSpace: "pre-wrap",
+                                    wordBreak: "break-all",
+                                }}
+                            >
+                                {highlightKeyword(line)}
+                            </Box>
+                        ))
+                    )}
+                </Paper>
+            )}
+
+            {!logs && !loading && !error && (
+                <Typography color="text.secondary" variant="body2">
+                    Select a component and click <strong>Fetch Logs</strong>.
+                </Typography>
+            )}
+        </Box>
+    );
+};
+
+export default SchedulerLogs;

--- a/frontend/src/components/scheduler/SchedulerMetrics.jsx
+++ b/frontend/src/components/scheduler/SchedulerMetrics.jsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { Alert, Box, Typography } from "@mui/material";
+import BarChartIcon from "@mui/icons-material/BarChart";
+
+/**
+ * Placeholder for the Metrics tab.
+ * Full Prometheus metric parsing and chart rendering will be implemented
+ * in a follow-up PR that adds GET /api/scheduler/metrics on the backend.
+ */
+const SchedulerMetrics = () => (
+    <Box
+        sx={{
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            py: 8,
+            gap: 2,
+        }}
+    >
+        <BarChartIcon sx={{ fontSize: 64, color: "text.disabled" }} />
+        <Typography variant="h6" color="text.secondary">
+            Metrics coming soon
+        </Typography>
+        <Alert severity="info" sx={{ maxWidth: 480 }}>
+            The Metrics tab will surface scheduler Prometheus data (scheduling
+            latency, preemption counts, unschedulable job/task counts) once the{" "}
+            <code>GET /api/scheduler/metrics</code> endpoint is merged.
+        </Alert>
+    </Box>
+);
+
+export default SchedulerMetrics;

--- a/frontend/src/components/scheduler/SchedulerMetrics.jsx
+++ b/frontend/src/components/scheduler/SchedulerMetrics.jsx
@@ -1,33 +1,231 @@
-import React from "react";
-import { Alert, Box, Typography } from "@mui/material";
-import BarChartIcon from "@mui/icons-material/BarChart";
+import React, { useCallback, useEffect, useState } from "react";
+import axios from "axios";
+import {
+    Alert,
+    Box,
+    Button,
+    Card,
+    CardContent,
+    CircularProgress,
+    Grid,
+    Tooltip,
+    Typography,
+} from "@mui/material";
+import RefreshIcon from "@mui/icons-material/Refresh";
+import { Bar, Line } from "react-chartjs-2";
+import "../Charts/chartConfig";
 
-/**
- * Placeholder for the Metrics tab.
- * Full Prometheus metric parsing and chart rendering will be implemented
- * in a follow-up PR that adds GET /api/scheduler/metrics on the backend.
- */
-const SchedulerMetrics = () => (
-    <Box
-        sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            py: 8,
-            gap: 2,
-        }}
-    >
-        <BarChartIcon sx={{ fontSize: 64, color: "text.disabled" }} />
-        <Typography variant="h6" color="text.secondary">
-            Metrics coming soon
-        </Typography>
-        <Alert severity="info" sx={{ maxWidth: 480 }}>
-            The Metrics tab will surface scheduler Prometheus data (scheduling
-            latency, preemption counts, unschedulable job/task counts) once the{" "}
-            <code>GET /api/scheduler/metrics</code> endpoint is merged.
-        </Alert>
-    </Box>
+// ── Stat card ─────────────────────────────────────────────────────────────────
+
+const StatCard = ({ label, value, color = "text.primary", tooltip }) => (
+    <Card variant="outlined" sx={{ height: "100%" }}>
+        <CardContent>
+            <Tooltip title={tooltip || ""} placement="top">
+                <Typography variant="caption" color="text.secondary" noWrap>
+                    {label}
+                </Typography>
+            </Tooltip>
+            <Typography variant="h4" fontWeight={700} color={color} sx={{ mt: 0.5 }}>
+                {value === null || value === undefined ? "—" : value}
+            </Typography>
+        </CardContent>
+    </Card>
 );
+
+// ── Chart helpers ──────────────────────────────────────────────────────────────
+
+const makeLineDataset = (series, labelKey = "action") => ({
+    labels: series.map((p) => p.labels?.[labelKey] || "unknown"),
+    datasets: [
+        {
+            label: "Latency (ms)",
+            data: series.map((p) => p.value),
+            borderColor: "#2196f3",
+            backgroundColor: "rgba(33,150,243,0.15)",
+            tension: 0.3,
+            fill: true,
+            pointRadius: 4,
+        },
+    ],
+});
+
+const makeBarDataset = (series, labelKey = "action") => ({
+    labels: series.map((p) => p.labels?.[labelKey] || "unknown"),
+    datasets: [
+        {
+            label: "Latency (ms)",
+            data: series.map((p) => p.value),
+            backgroundColor: "#4caf50",
+            borderColor: "#388e3c",
+            borderWidth: 1,
+        },
+    ],
+});
+
+const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: { legend: { display: false } },
+    scales: { y: { beginAtZero: true } },
+};
+
+// ── Component ──────────────────────────────────────────────────────────────────
+
+const SchedulerMetrics = () => {
+    const [data, setData] = useState(null);
+    const [loading, setLoading] = useState(false);
+    const [error, setError] = useState(null);
+    const [lastUpdated, setLastUpdated] = useState(null);
+
+    const fetchMetrics = useCallback(async () => {
+        setLoading(true);
+        setError(null);
+        try {
+            const res = await axios.get("/api/scheduler/metrics");
+            setData(res.data);
+            setLastUpdated(new Date());
+        } catch (err) {
+            setError(
+                err.response?.data?.error ||
+                "Failed to fetch metrics: " + err.message,
+            );
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        fetchMetrics();
+    }, [fetchMetrics]);
+
+    const m = data?.metrics;
+
+    return (
+        <Box>
+            {/* Header */}
+            <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mb: 3 }}>
+                <Box>
+                    {data && (
+                        <Typography variant="caption" color="text.secondary">
+                            Pod: <strong>{data.pod}</strong> &nbsp;·&nbsp; Last updated:{" "}
+                            {lastUpdated?.toLocaleTimeString()}
+                        </Typography>
+                    )}
+                </Box>
+                <Button
+                    size="small"
+                    startIcon={loading ? <CircularProgress size={14} /> : <RefreshIcon />}
+                    onClick={fetchMetrics}
+                    disabled={loading}
+                >
+                    Refresh
+                </Button>
+            </Box>
+
+            {error && (
+                <Alert severity="error" action={
+                    <Button color="inherit" size="small" onClick={fetchMetrics}>Retry</Button>
+                } sx={{ mb: 3 }}>
+                    {error}
+                </Alert>
+            )}
+
+            {loading && !data && (
+                <Box sx={{ display: "flex", justifyContent: "center", py: 8 }}>
+                    <CircularProgress />
+                </Box>
+            )}
+
+            {m && (
+                <>
+                    {/* ── Stat cards ── */}
+                    <Grid container spacing={2} sx={{ mb: 4 }}>
+                        {[
+                            {
+                                label: "Unschedulable Jobs",
+                                value: m.statCards.unschedulableJobs,
+                                color: m.statCards.unschedulableJobs > 0 ? "error.main" : "success.main",
+                                tooltip: "volcano_queue_unschedulable_task_count",
+                            },
+                            {
+                                label: "Unschedulable Tasks",
+                                value: m.statCards.unschedulableTasks,
+                                color: m.statCards.unschedulableTasks > 0 ? "warning.main" : "success.main",
+                                tooltip: "volcano_task_unschedulable_count",
+                            },
+                            {
+                                label: "Preemption Victims",
+                                value: m.statCards.preemptionVictims,
+                                tooltip: "volcano_preemption_victims",
+                            },
+                            {
+                                label: "Preemption Attempts",
+                                value: m.statCards.preemptionAttempts,
+                                tooltip: "volcano_preemption_attempts_total",
+                            },
+                        ].map((card) => (
+                            <Grid item xs={6} md={3} key={card.label}>
+                                <StatCard {...card} />
+                            </Grid>
+                        ))}
+                    </Grid>
+
+                    {/* ── E2E latency line chart ── */}
+                    {m.charts.e2eLatency.length > 0 && (
+                        <Box sx={{ mb: 4 }}>
+                            <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+                                E2E Scheduling Latency (ms)
+                            </Typography>
+                            <Box sx={{ height: 220 }}>
+                                <Line
+                                    data={makeLineDataset(m.charts.e2eLatency, "quantile")}
+                                    options={chartOptions}
+                                />
+                            </Box>
+                        </Box>
+                    )}
+
+                    {/* ── Per-action latency bar chart ── */}
+                    {m.charts.actionLatency.length > 0 && (
+                        <Box sx={{ mb: 4 }}>
+                            <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+                                Per-Action Scheduling Latency (ms)
+                            </Typography>
+                            <Box sx={{ height: 220 }}>
+                                <Bar
+                                    data={makeBarDataset(m.charts.actionLatency, "action")}
+                                    options={chartOptions}
+                                />
+                            </Box>
+                        </Box>
+                    )}
+
+                    {/* ── Per-plugin latency bar chart ── */}
+                    {m.charts.pluginLatency.length > 0 && (
+                        <Box sx={{ mb: 4 }}>
+                            <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 1 }}>
+                                Per-Plugin Scheduling Latency (ms)
+                            </Typography>
+                            <Box sx={{ height: 220 }}>
+                                <Bar
+                                    data={makeBarDataset(m.charts.pluginLatency, "plugin")}
+                                    options={chartOptions}
+                                />
+                            </Box>
+                        </Box>
+                    )}
+
+                    {m.charts.e2eLatency.length === 0 &&
+                        m.charts.actionLatency.length === 0 && (
+                            <Alert severity="info">
+                                No latency series found in the metrics response. Scheduling latency
+                                metrics are emitted after the scheduler processes at least one cycle.
+                            </Alert>
+                        )}
+                </>
+            )}
+        </Box>
+    );
+};
 
 export default SchedulerMetrics;


### PR DESCRIPTION
## Summary

Part of #197 — builds on #203 (backend) and #204 (frontend) to deliver the Metrics tab for the Scheduler section.

### Backend: `GET /api/scheduler/metrics`

New endpoint added to `backend/src/server.js`:

1. Resolves the running `volcano-scheduler` pod by label selector (reuses `resolveComponentPod` from #203)
2. Proxies the pod's `/metrics` endpoint through the Kubernetes API server via `connectGetNamespacedPodProxyWithPath` (no direct pod-to-backend network path needed)
3. Parses the Prometheus text format with a zero-dependency parser (`parsePrometheusText`)
4. Returns a structured JSON object:

```json
{
  "pod": "volcano-scheduler-abc123",
  "namespace": "volcano-system",
  "metrics": {
    "statCards": {
      "unschedulableJobs": 3,
      "unschedulableTasks": 0,
      "preemptionVictims": 1,
      "preemptionAttempts": 5
    },
    "charts": {
      "e2eLatency": [{ "labels": { "quantile": "0.99" }, "value": 120.5 }],
      "actionLatency": [{ "labels": { "action": "allocate" }, "value": 42.5 }],
      "pluginLatency": []
    }
  }
}
```

### Frontend: `SchedulerMetrics.jsx`

Replaces the placeholder from #204 with a fully functional tab:

| UI element | Source metric |
|---|---|
| Unschedulable Jobs stat card (red when > 0) | `volcano_queue_unschedulable_task_count` |
| Unschedulable Tasks stat card | `volcano_task_unschedulable_count` |
| Preemption Victims stat card | `volcano_preemption_victims` |
| Preemption Attempts stat card | `volcano_preemption_attempts_total` |
| E2E latency **line chart** | `volcano_e2e_scheduling_latency_milliseconds` |
| Per-action latency **bar chart** | `volcano_task_scheduling_latency_milliseconds` |
| Per-plugin latency **bar chart** | `volcano_plugin_scheduling_latency_milliseconds` |

Uses the existing `react-chartjs-2` + `chart.js` stack already in the project.

### Tests

`backend/tests/server.test.js` gains 2 new cases:
- Success: verifies unschedulableJobs=3, preemptionVictims=1, actionLatency has 2 entries
- 404 when no scheduler pod is running

## Test plan
- [ ] `npm test` in `backend/` — all tests pass
- [ ] With a live cluster: `/api/scheduler/metrics` returns populated data
- [ ] Metrics tab: stat cards show values, charts render latency series
- [ ] When no latency series emitted yet: info banner shown instead of empty charts
- [ ] Error state: Retry button refetches