### PR TITLE
ci: optimize workflows with path matching rules (#120)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,21 @@ name: Build and Deploy
 
 on:
   push:
-    branches: '*'
+    branches: ['*']
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'deployment/**'
+      - '.github/workflows/build.yml'
+      - 'package*.json'
+  pull_request:
+    branches: ['*']
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - 'deployment/**'
+      - '.github/workflows/build.yml'
+      - 'package*.json'
 
 jobs:
   frontend-build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,18 @@ name: Run Tests
 on:
   push:
     branches: ['*']
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - '.github/workflows/test.yml'
+      - 'package*.json'
   pull_request:
     branches: ['*']
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
+      - '.github/workflows/test.yml'
+      - 'package*.json'
 
 jobs:
   frontend-tests:


### PR DESCRIPTION
This PR fully addresses #120 by adding path-match filtering to our testing and build workflows so they only trigger when relevant files actually change. It's a small optimisation, but it will save everyone a ton of time and resources on CI builds