### PR TITLE
Implement pod deletion and editing functionality in the dashboard

### DIFF
--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -559,6 +559,111 @@ app.get("/api/pod/:namespace/:name/yaml", async (req, res) => {
     }
 });
 
+app.delete("/api/pod/:namespace/:name", async (req, res) => {
+    const { namespace, name } = req.params;
+
+    try {
+        const response = await k8sCoreApi.deleteNamespacedPod({
+            name,
+            namespace,
+            body: { propagationPolicy: "Foreground" },
+        });
+
+        return res.json({
+            message: "Pod deleted successfully",
+            data: response.body,
+        });
+    } catch (err) {
+        const statusCode = err?.statusCode || err?.response?.statusCode || 500;
+        let message = "An unexpected error occurred.";
+
+        try {
+            const rawBody = err?.body || err?.response?.body;
+            const parsedBody =
+                typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody;
+
+            if (parsedBody?.message) {
+                message = parsedBody.message;
+            }
+        } catch {
+            message = err?.message || message;
+        }
+
+        console.error("Error deleting pod:", err);
+
+        return res.status(statusCode).json({
+            error: "Failed to delete pod",
+            message,
+            code: statusCode,
+        });
+    }
+});
+
+app.patch("/api/pod/:namespace/:name", async (req, res) => {
+    const { namespace, name } = req.params;
+
+    try {
+        const patchData = req.body || {};
+        const sanitizedPatch = {
+            ...patchData,
+            metadata: {
+                ...(patchData.metadata || {}),
+                name,
+                namespace,
+            },
+        };
+
+        delete sanitizedPatch.status;
+
+        const response = await k8sCoreApi.patchNamespacedPod({
+            name,
+            namespace,
+            body: sanitizedPatch,
+            options: {
+                headers: { "Content-Type": "application/merge-patch+json" },
+            },
+        });
+
+        return res.json({
+            message: "Pod updated successfully",
+            data: response.body,
+        });
+    } catch (err) {
+        const statusCode = err?.statusCode || err?.response?.statusCode || 500;
+        let message = "An unexpected error occurred.";
+        let details = null;
+        let reason = null;
+
+        try {
+            const rawBody = err?.body || err?.response?.body;
+            const parsedBody =
+                typeof rawBody === "string" ? JSON.parse(rawBody) : rawBody;
+
+            if (parsedBody?.message) {
+                message = parsedBody.message;
+            }
+            if (parsedBody?.details) {
+                details = parsedBody.details;
+            }
+            if (parsedBody?.reason) {
+                reason = parsedBody.reason;
+            }
+        } catch {
+            message = err?.message || message;
+        }
+
+        console.error("Error updating pod:", err);
+
+        return res.status(statusCode).json({
+            error: "Failed to update pod",
+            message,
+            details,
+            reason,
+            code: statusCode,
+        });
+    }
+});
+
 // Get all Jobs (no pagination)
 app.get("/api/all-jobs", async (req, res) => {
     try {

--- a/backend/tests/server.test.js
+++ b/backend/tests/server.test.js
@@ -1,7 +1,7 @@
 import sinon from "sinon";
 import request from "supertest";
 import { app } from "../src/server.js";
-import { CustomObjectsApi } from "@kubernetes/client-node";
+import { CoreV1Api, CustomObjectsApi } from "@kubernetes/client-node";
 
 describe("backend", () => {
     let sandbox;
@@ -77,5 +77,34 @@ describe("backend", () => {
         expect(res.status).toBe(200);
         expect(res.body.items).toHaveLength(2);
         expect(res.body.items[0].metadata.name).toBe("pg1");
+    });
+
+    it("should delete a pod", async () => {
+        sandbox.stub(CoreV1Api.prototype, "deleteNamespacedPod").resolves({
+            body: { status: "Success" },
+        });
+
+        const res = await request(app).delete("/api/pod/default/pod-1");
+
+        expect(res.status).toBe(200);
+        expect(res.body.message).toBe("Pod deleted successfully");
+    });
+
+    it("should update a pod", async () => {
+        sandbox.stub(CoreV1Api.prototype, "patchNamespacedPod").resolves({
+            body: {
+                metadata: { name: "pod-1", namespace: "default" },
+            },
+        });
+
+        const res = await request(app)
+            .patch("/api/pod/default/pod-1")
+            .send({
+                metadata: { labels: { app: "updated" } },
+                spec: { containers: [] },
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.message).toBe("Pod updated successfully");
     });
 });

--- a/frontend/src/components/pods/PodEditDialog.jsx
+++ b/frontend/src/components/pods/PodEditDialog.jsx
@@ -1,0 +1,231 @@
+import React, { useEffect, useState } from "react";
+import {
+    Alert,
+    Box,
+    Dialog,
+    DialogTitle,
+    DialogContent,
+    DialogActions,
+    Button,
+    TextField,
+    ToggleButton,
+    ToggleButtonGroup,
+} from "@mui/material";
+import Editor from "@monaco-editor/react";
+import yaml from "js-yaml";
+
+const PodEditDialog = ({ open, pod, onClose, onSave, error, isSaving }) => {
+    const [editorValue, setEditorValue] = useState("");
+    const [editMode, setEditMode] = useState("yaml");
+    const [formState, setFormState] = useState(null);
+    const [localError, setLocalError] = useState("");
+
+    const updateNestedValue = (obj, path, value) => {
+        const next = yaml.load(yaml.dump(obj));
+        let current = next;
+
+        for (let index = 0; index < path.length - 1; index += 1) {
+            const key = path[index];
+            if (current[key] === undefined || current[key] === null) {
+                current[key] = typeof path[index + 1] === "number" ? [] : {};
+            }
+            current = current[key];
+        }
+
+        current[path[path.length - 1]] = value;
+        return next;
+    };
+
+    const extractFormState = (podValue) => {
+        return yaml.load(yaml.dump(podValue));
+    };
+
+    useEffect(() => {
+        if (open && pod) {
+            setEditorValue(yaml.dump(pod));
+            setFormState(extractFormState(pod));
+            setEditMode("yaml");
+            setLocalError("");
+        }
+    }, [open, pod]);
+
+    const handleModeChange = (event, newMode) => {
+        if (newMode !== null) {
+            if (newMode === "form") {
+                try {
+                    const parsed = yaml.load(editorValue);
+                    setFormState(parsed);
+                    setLocalError("");
+                } catch {
+                    setLocalError("Unable to switch to form view because the YAML is invalid.");
+                    return;
+                }
+            }
+
+            if (newMode === "yaml" && formState) {
+                setEditorValue(yaml.dump(formState));
+            }
+
+            setEditMode(newMode);
+        }
+    };
+
+    const handleSave = async () => {
+        try {
+            const updatedPod =
+                editMode === "yaml" ? yaml.load(editorValue) : formState;
+
+            if (!updatedPod?.metadata?.name || !updatedPod?.metadata?.namespace) {
+                setLocalError("Pod metadata.name and metadata.namespace are required.");
+                return;
+            }
+
+            if (pod?.metadata?.name && updatedPod.metadata.name !== pod.metadata.name) {
+                setLocalError(
+                    `Pod rename is not supported. Original name: ${pod.metadata.name}. Keep metadata.name unchanged.`,
+                );
+                return;
+            }
+
+            if (
+                pod?.metadata?.namespace &&
+                updatedPod.metadata.namespace !== pod.metadata.namespace
+            ) {
+                setLocalError(
+                    `Pod namespace change is not supported for this update flow. Original namespace: ${pod.metadata.namespace}.`,
+                );
+                return;
+            }
+
+            setLocalError("");
+            const result = await onSave(updatedPod);
+
+            if (result !== false) {
+                onClose();
+            }
+        } catch (err) {
+            console.error("Save failed:", err);
+        }
+    };
+
+    return (
+        <Dialog open={open} onClose={onClose} maxWidth="md" fullWidth>
+            <DialogTitle
+                sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                }}
+            >
+                Edit Pod
+                <ToggleButtonGroup
+                    value={editMode}
+                    exclusive
+                    onChange={handleModeChange}
+                    color="primary"
+                >
+                    <ToggleButton value="yaml">YAML</ToggleButton>
+                    <ToggleButton value="form">Form</ToggleButton>
+                </ToggleButtonGroup>
+            </DialogTitle>
+            <DialogContent sx={{ height: "500px" }}>
+                {(localError || error) && (
+                    <Alert severity="error" sx={{ mb: 2 }}>
+                        {localError || error}
+                    </Alert>
+                )}
+                {editMode === "yaml" ? (
+                    <Editor
+                        height="100%"
+                        language="yaml"
+                        value={editorValue}
+                        onChange={(val) => setEditorValue(val || "")}
+                        options={{
+                            minimap: { enabled: false },
+                            automaticLayout: true,
+                        }}
+                    />
+                ) : (
+                    <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+                        <TextField
+                            label="metadata.name"
+                            value={formState?.metadata?.name || ""}
+                            onChange={(event) =>
+                                setFormState((current) =>
+                                    updateNestedValue(
+                                        current,
+                                        ["metadata", "name"],
+                                        event.target.value,
+                                    ),
+                                )
+                            }
+                            fullWidth
+                        />
+                        <TextField
+                            label="metadata.namespace"
+                            value={formState?.metadata?.namespace || ""}
+                            onChange={(event) =>
+                                setFormState((current) =>
+                                    updateNestedValue(
+                                        current,
+                                        ["metadata", "namespace"],
+                                        event.target.value,
+                                    ),
+                                )
+                            }
+                            fullWidth
+                        />
+                        <TextField
+                            label="spec.containers[0].name"
+                            value={formState?.spec?.containers?.[0]?.name || ""}
+                            onChange={(event) =>
+                                setFormState((current) =>
+                                    updateNestedValue(
+                                        current,
+                                        ["spec", "containers", 0, "name"],
+                                        event.target.value,
+                                    ),
+                                )
+                            }
+                            fullWidth
+                        />
+                        <TextField
+                            label="spec.containers[0].image"
+                            value={formState?.spec?.containers?.[0]?.image || ""}
+                            onChange={(event) =>
+                                setFormState((current) =>
+                                    updateNestedValue(
+                                        current,
+                                        ["spec", "containers", 0, "image"],
+                                        event.target.value,
+                                    ),
+                                )
+                            }
+                            fullWidth
+                        />
+                    </Box>
+                )}
+            </DialogContent>
+            <DialogActions>
+                <Button
+                    onClick={onClose}
+                    color="primary"
+                    variant="contained"
+                    disabled={isSaving}
+                >
+                    Cancel
+                </Button>
+                <Button
+                    onClick={handleSave}
+                    color="primary"
+                    variant="contained"
+                    disabled={isSaving}
+                >
+                    {isSaving ? "Updating..." : "Update"}
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default PodEditDialog;

--- a/frontend/src/components/pods/PodTableDeleteDialog.jsx
+++ b/frontend/src/components/pods/PodTableDeleteDialog.jsx
@@ -1,0 +1,67 @@
+import React from "react";
+import {
+    Alert,
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    IconButton,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+
+const PodTableDeleteDialog = ({
+    open,
+    onClose,
+    onConfirm,
+    podToDelete,
+    error,
+    isDeleting,
+}) => {
+    const showOnlyError = Boolean(error);
+
+    return (
+        <Dialog open={open} onClose={onClose}>
+            <DialogTitle
+                sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                }}
+            >
+                {showOnlyError ? "Error" : "Delete Pod"}
+                <IconButton onClick={onClose} size="small">
+                    <CloseIcon />
+                </IconButton>
+            </DialogTitle>
+
+            <DialogContent>
+                {showOnlyError ? (
+                    <Alert severity="error">{error}</Alert>
+                ) : (
+                    `Are you sure you want to delete pod "${podToDelete}"? This action cannot be undone.`
+                )}
+            </DialogContent>
+
+            <DialogActions>
+                {!showOnlyError && (
+                    <Button onClick={onClose} color="primary" disabled={isDeleting}>
+                        Cancel
+                    </Button>
+                )}
+                {!showOnlyError && (
+                    <Button
+                        onClick={onConfirm}
+                        color="error"
+                        variant="contained"
+                        disabled={isDeleting}
+                    >
+                        {isDeleting ? "Deleting..." : "Delete"}
+                    </Button>
+                )}
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default PodTableDeleteDialog;

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -1,12 +1,15 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import axios from "axios";
+import yaml from "js-yaml";
 import SearchBar from "../Searchbar";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces } from "../utils";
 import PodsTable from "./PodsTable/PodsTable";
 import PodsPagination from "./PodsPagination";
 import PodDetailsDialog from "./PodDetailsDialog";
+import PodEditDialog from "./PodEditDialog";
+import PodTableDeleteDialog from "./PodTableDeleteDialog";
 
 const Pods = () => {
     const [pods, setPods] = useState([]);
@@ -23,6 +26,14 @@ const Pods = () => {
     const [searchText, setSearchText] = useState("");
     const theme = useTheme();
     const [selectedPodName, setSelectedPodName] = useState("");
+    const [openEditDialog, setOpenEditDialog] = useState(false);
+    const [podToEdit, setPodToEdit] = useState(null);
+    const [editError, setEditError] = useState(null);
+    const [isSaving, setIsSaving] = useState(false);
+    const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
+    const [podToDelete, setPodToDelete] = useState(null);
+    const [deleteError, setDeleteError] = useState(null);
+    const [isDeleting, setIsDeleting] = useState(false);
     const [pagination, setPagination] = useState({
         page: 1,
         rowsPerPage: 10,
@@ -74,6 +85,30 @@ const Pods = () => {
         setPagination((prev) => ({ ...prev, page: 1 }));
     };
 
+    const formatYamlForDisplay = useCallback((yamlText) => {
+        return yamlText
+            .split("\n")
+            .map((line) => {
+                const keyMatch = line.match(/^(\s*)([^:\s]+):/);
+                if (keyMatch) {
+                    const [, indent, key] = keyMatch;
+                    const value = line.slice(keyMatch[0].length);
+                    return `${indent}<span class="yaml-key">${key}</span>:${value}`;
+                }
+                return line;
+            })
+            .join("\n");
+    }, []);
+
+    const fetchPodYaml = useCallback(async (pod) => {
+        const response = await axios.get(
+            `/api/pod/${pod.metadata.namespace}/${pod.metadata.name}/yaml`,
+            { responseType: "text" },
+        );
+
+        return response.data;
+    }, []);
+
     const handleClearSearch = () => {
         setSearchText("");
         setPagination((prev) => ({ ...prev, page: 1 }));
@@ -85,18 +120,6 @@ const Pods = () => {
         setSearchText("");
         fetchPods();
     }, [fetchPods]);
-
-    const fetchData = async () => {
-        try {
-            const response = await fetch("/api/pods");
-            if (response.ok) {
-                const data = await response.json();
-                setPods(data);
-            }
-        } catch (error) {
-            console.error("Error fetching pods:", error);
-        }
-    };
 
     const handleCreatePod = async (newPod) => {
         try {
@@ -119,7 +142,7 @@ const Pods = () => {
             }
 
             alert("Pod created successfully!");
-            await fetchData(); // Now fetchData is defined in the same scope
+            await fetchPods();
         } catch (err) {
             alert("Network error: " + err.message);
         }
@@ -128,26 +151,9 @@ const Pods = () => {
     const handlePodClick = useCallback(async (pod) => {
         try {
             setLoading(true);
-            const response = await axios.get(
-                `/api/pod/${pod.metadata.namespace}/${pod.metadata.name}/yaml`,
-                { responseType: "text" },
-            );
-
-            const formattedYaml = response.data
-                .split("\n")
-                .map((line) => {
-                    const keyMatch = line.match(/^(\s*)([^:\s]+):/);
-                    if (keyMatch) {
-                        const [, indent, key] = keyMatch;
-                        const value = line.slice(keyMatch[0].length);
-                        return `${indent}<span class="yaml-key">${key}</span>:${value}`;
-                    }
-                    return line;
-                })
-                .join("\n");
-
+            const yamlText = await fetchPodYaml(pod);
             setSelectedPodName(pod.metadata.name);
-            setSelectedPodYaml(formattedYaml);
+            setSelectedPodYaml(formatYamlForDisplay(yamlText));
             setOpenDialog(true);
         } catch (err) {
             console.error("Failed to fetch pod YAML:", err);
@@ -155,11 +161,223 @@ const Pods = () => {
         } finally {
             setLoading(false);
         }
-    }, []);
+    }, [fetchPodYaml, formatYamlForDisplay]);
+
+    const handleOpenEditDialog = useCallback(async (pod) => {
+        try {
+            setLoading(true);
+            setEditError(null);
+            const yamlText = await fetchPodYaml(pod);
+            setPodToEdit(yaml.load(yamlText));
+            setOpenEditDialog(true);
+        } catch (err) {
+            console.error("Failed to fetch pod YAML for edit:", err);
+            setError("Failed to fetch pod YAML: " + err.message);
+        } finally {
+            setLoading(false);
+        }
+    }, [fetchPodYaml]);
 
     const handleCloseDialog = useCallback(() => {
         setOpenDialog(false);
     }, []);
+
+    const handleCloseEditDialog = useCallback(() => {
+        setOpenEditDialog(false);
+        setPodToEdit(null);
+        setEditError(null);
+        setIsSaving(false);
+    }, []);
+
+    const handleSavePod = useCallback(async (updatedPod) => {
+        const originalNamespace = podToEdit?.metadata?.namespace;
+        const originalName = podToEdit?.metadata?.name;
+
+        if (!updatedPod?.metadata?.namespace || !updatedPod?.metadata?.name) {
+            setEditError("Pod metadata.name and metadata.namespace are required.");
+            return false;
+        }
+
+        if (!originalNamespace || !originalName) {
+            setEditError("Unable to determine the original pod identity.");
+            return false;
+        }
+
+        setIsSaving(true);
+        setEditError(null);
+
+        try {
+            const response = await fetch(
+                `/api/pod/${encodeURIComponent(originalNamespace)}/${encodeURIComponent(originalName)}`,
+                {
+                    method: "PATCH",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Accept: "application/json",
+                    },
+                    body: JSON.stringify(updatedPod),
+                },
+            );
+
+            const contentType = response.headers.get("content-type");
+            const text = await response.text();
+            let data = {};
+
+            try {
+                data =
+                    contentType && contentType.includes("application/json") && text
+                        ? JSON.parse(text)
+                        : { message: text };
+            } catch {
+                data = { message: text };
+            }
+
+            if (!response.ok) {
+                const detailParts = [];
+                const displayName = data?.details?.name || updatedPod.metadata.name;
+
+                if (data.message) {
+                    detailParts.push(data.message);
+                }
+
+                if (data.reason) {
+                    detailParts.push(`Reason: ${data.reason}`);
+                }
+
+                if (data.details) {
+                    if (typeof data.details === "object") {
+                        const fieldParts = [];
+                        if (data.details.name) fieldParts.push(`name=${data.details.name}`);
+                        if (data.details.kind) fieldParts.push(`kind=${data.details.kind}`);
+                        if (fieldParts.length > 0) {
+                            detailParts.push(`Details: ${fieldParts.join(", ")}`);
+                        }
+                    } else {
+                        detailParts.push(`Details: ${data.details}`);
+                    }
+                }
+
+                setEditError(
+                    detailParts.length > 0
+                        ? `Pod "${originalNamespace}/${displayName}" could not be updated. ${detailParts.join(" • ")}`
+                        : text ||
+                            `Pod "${originalNamespace}/${displayName}" could not be updated.`,
+                );
+                return false;
+            }
+
+            const updatedFromServer = data.data || updatedPod;
+            setCachedPods((currentPods) =>
+                currentPods.map((pod) =>
+                    pod.metadata.namespace === originalNamespace &&
+                    pod.metadata.name === originalName
+                        ? updatedFromServer
+                        : pod,
+                ),
+            );
+            setPods((currentPods) =>
+                currentPods.map((pod) =>
+                    pod.metadata.namespace === originalNamespace &&
+                    pod.metadata.name === originalName
+                        ? updatedFromServer
+                        : pod,
+                ),
+            );
+
+            return updatedFromServer;
+        } catch (err) {
+            setEditError(err.message || "An unexpected error occurred.");
+            return false;
+        } finally {
+            setIsSaving(false);
+        }
+    }, [podToEdit]);
+
+    const handleOpenDeleteDialog = useCallback((pod) => {
+        setPodToDelete(pod);
+        setDeleteError(null);
+        setOpenDeleteDialog(true);
+    }, []);
+
+    const handleCloseDeleteDialog = useCallback(() => {
+        setOpenDeleteDialog(false);
+        setPodToDelete(null);
+        setDeleteError(null);
+        setIsDeleting(false);
+    }, []);
+
+    const handleDeletePod = useCallback(async () => {
+        if (!podToDelete) {
+            return;
+        }
+
+        setIsDeleting(true);
+
+        try {
+            const { namespace, name } = podToDelete.metadata;
+            const response = await fetch(
+                `/api/pod/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+                {
+                    method: "DELETE",
+                    headers: {
+                        "Content-Type": "application/json",
+                        Accept: "application/json",
+                    },
+                },
+            );
+
+            const contentType = response.headers.get("content-type");
+            const text = await response.text();
+            let data = {};
+
+            try {
+                data =
+                    contentType && contentType.includes("application/json") && text
+                        ? JSON.parse(text)
+                        : { message: text };
+            } catch {
+                data = { message: text };
+            }
+
+            if (!response.ok) {
+                setDeleteError(
+                    data.message ||
+                        data.details ||
+                        text ||
+                        `Pod "${namespace}/${name}" could not be deleted.`,
+                );
+                return;
+            }
+
+            setCachedPods((currentPods) =>
+                currentPods.filter(
+                    (pod) =>
+                        !(
+                            pod.metadata.namespace === namespace &&
+                            pod.metadata.name === name
+                        ),
+                ),
+            );
+            setTotalPods((currentTotal) => Math.max(currentTotal - 1, 0));
+            setPagination((currentPagination) => {
+                const nextTotal = Math.max(totalPods - 1, 0);
+                const maxPage = Math.max(
+                    1,
+                    Math.ceil(nextTotal / currentPagination.rowsPerPage),
+                );
+
+                return {
+                    ...currentPagination,
+                    page: Math.min(currentPagination.page, maxPage),
+                };
+            });
+            handleCloseDeleteDialog();
+        } catch (err) {
+            setDeleteError(err.message || "An unexpected error occurred.");
+        } finally {
+            setIsDeleting(false);
+        }
+    }, [handleCloseDeleteDialog, podToDelete, totalPods]);
 
     const handleFilterChange = useCallback((filterType, value) => {
         setFilters((prev) => ({ ...prev, [filterType]: value }));
@@ -211,6 +429,8 @@ const Pods = () => {
                 onSortDirectionToggle={toggleSortDirection}
                 onFilterChange={handleFilterChange}
                 onPodClick={handlePodClick}
+                onOpenEditDialog={handleOpenEditDialog}
+                onOpenDeleteDialog={handleOpenDeleteDialog}
             />
             <PodsPagination
                 totalPods={totalPods}
@@ -222,6 +442,26 @@ const Pods = () => {
                 podName={selectedPodName}
                 podYaml={selectedPodYaml}
                 onClose={handleCloseDialog}
+            />
+            <PodEditDialog
+                open={openEditDialog}
+                pod={podToEdit}
+                onClose={handleCloseEditDialog}
+                onSave={handleSavePod}
+                error={editError}
+                isSaving={isSaving}
+            />
+            <PodTableDeleteDialog
+                open={openDeleteDialog}
+                onClose={handleCloseDeleteDialog}
+                onConfirm={handleDeletePod}
+                podToDelete={
+                    podToDelete
+                        ? `${podToDelete.metadata.namespace}/${podToDelete.metadata.name}`
+                        : ""
+                }
+                error={deleteError}
+                isDeleting={isDeleting}
             />
         </Box>
     );

--- a/frontend/src/components/pods/PodsTable/PodRow.jsx
+++ b/frontend/src/components/pods/PodsTable/PodRow.jsx
@@ -1,14 +1,33 @@
 import React from "react";
-import { TableRow, TableCell, Chip, useTheme, alpha } from "@mui/material";
+import {
+    Box,
+    Chip,
+    IconButton,
+    TableCell,
+    TableRow,
+    useTheme,
+    alpha,
+} from "@mui/material";
+import { Delete, Edit } from "@mui/icons-material";
 import { calculateAge } from "../../utils";
 
-const PodRow = ({ pod, getStatusColor, onPodClick }) => {
+const PodRow = ({
+    pod,
+    getStatusColor,
+    onPodClick,
+    onOpenEditDialog,
+    onOpenDeleteDialog,
+}) => {
     const theme = useTheme();
 
     return (
         <TableRow
             hover
-            onClick={() => onPodClick(pod)}
+            onClick={(event) => {
+                if (!event.target.closest("button")) {
+                    onPodClick(pod);
+                }
+            }}
             sx={{
                 height: "60px",
                 transition: "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
@@ -91,6 +110,47 @@ const PodRow = ({ pod, getStatusColor, onPodClick }) => {
                 }}
             >
                 {calculateAge(pod.metadata.creationTimestamp)}
+            </TableCell>
+
+            <TableCell sx={{ padding: "16px 24px" }}>
+                <Box display="flex" alignItems="center" gap={2}>
+                    <IconButton
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            onOpenEditDialog(pod);
+                        }}
+                        size="small"
+                        sx={{
+                            color: theme.palette.primary.main,
+                            "&:hover": {
+                                backgroundColor: alpha(
+                                    theme.palette.primary.main,
+                                    0.1,
+                                ),
+                            },
+                        }}
+                    >
+                        <Edit fontSize="small" />
+                    </IconButton>
+                    <IconButton
+                        onClick={(event) => {
+                            event.stopPropagation();
+                            onOpenDeleteDialog(pod);
+                        }}
+                        size="small"
+                        sx={{
+                            color: theme.palette.error.main,
+                            "&:hover": {
+                                backgroundColor: alpha(
+                                    theme.palette.error.main,
+                                    0.1,
+                                ),
+                            },
+                        }}
+                    >
+                        <Delete fontSize="small" />
+                    </IconButton>
+                </Box>
             </TableCell>
         </TableRow>
     );

--- a/frontend/src/components/pods/PodsTable/PodsTable.jsx
+++ b/frontend/src/components/pods/PodsTable/PodsTable.jsx
@@ -18,6 +18,8 @@ const PodsTable = ({
     onSortDirectionToggle,
     onFilterChange,
     onPodClick,
+    onOpenEditDialog,
+    onOpenDeleteDialog,
 }) => {
     const theme = useTheme();
     const [anchorEl, setAnchorEl] = React.useState({
@@ -126,6 +128,8 @@ const PodsTable = ({
                             pod={pod}
                             getStatusColor={getStatusColor}
                             onPodClick={onPodClick}
+                            onOpenEditDialog={onOpenEditDialog}
+                            onOpenDeleteDialog={onOpenDeleteDialog}
                         />
                     ))}
                 </TableBody>

--- a/frontend/src/components/pods/PodsTable/TableHeader.jsx
+++ b/frontend/src/components/pods/PodsTable/TableHeader.jsx
@@ -30,7 +30,7 @@ const TableHeader = ({
     return (
         <TableHead>
             <TableRow>
-                {["Name", "Namespace", "Creation Time", "Status", "Age"].map(
+                {["Name", "Namespace", "Creation Time", "Status", "Age", "Actions"].map(
                     (header) => (
                         <TableCell
                             key={header}


### PR DESCRIPTION
- Now we can delete pods from the ui
- We can edit pods from the UI now.
- Added YML and form view for editing the pods


<img width="1885" height="966" alt="Screenshot from 2026-05-08 01-54-03" src="https://github.com/user-attachments/assets/6a2344e9-0653-4bbf-a0af-d9aae7772a11" />
<img width="1885" height="966" alt="Screenshot from 2026-05-08 01-53-56" src="https://github.com/user-attachments/assets/78a08f97-ac27-462a-a06e-4e7c00823940" />
