### PR TITLE
fix: sanitize YAML content to prevent XSS in preview dialogs

### DIFF
--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import axios from "axios";
+import { escape } from "lodash";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces, fetchAllQueues } from "../utils";
 import JobTable from "./JobTable/JobTable";
@@ -104,9 +105,9 @@ const Jobs = () => {
                     if (keyMatch) {
                         const [, indent, key] = keyMatch;
                         const value = line.slice(keyMatch[0].length);
-                        return `${indent}<span class="yaml-key">${key}</span>:${value}`;
+                        return `${indent}<span class="yaml-key">${escape(key)}</span>:${escape(value)}`;
                     }
-                    return line;
+                    return escape(line);
                 })
                 .join("\n");
 

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import axios from "axios";
+import { escape } from "lodash";
 import SearchBar from "../Searchbar";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces } from "../utils";
@@ -140,9 +141,9 @@ const Pods = () => {
                     if (keyMatch) {
                         const [, indent, key] = keyMatch;
                         const value = line.slice(keyMatch[0].length);
-                        return `${indent}<span class="yaml-key">${key}</span>:${value}`;
+                        return `${indent}<span class="yaml-key">${escape(key)}</span>:${escape(value)}`;
                     }
-                    return line;
+                    return escape(line);
                 })
                 .join("\n");
 

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import axios from "axios";
+import { escape } from "lodash";
 import { parseCPU, parseMemoryToMi } from "../utils";
 import SearchBar from "../Searchbar";
 import QueueTable from "./QueueTable/QueueTable";
@@ -111,9 +112,9 @@ const Queues = () => {
                     if (keyMatch) {
                         const [, indent, key] = keyMatch;
                         const value = line.slice(keyMatch[0].length);
-                        return `${indent}<span class="yaml-key">${key}</span>:${value}`;
+                        return `${indent}<span class="yaml-key">${escape(key)}</span>:${escape(value)}`;
                     }
-                    return line;
+                    return escape(line);
                 })
                 .join("\n");
 


### PR DESCRIPTION
### Description:

**What's the problem?**
While going through the codebase, I noticed that the YAML preview dialogs for Jobs, Pods, and Queues use dangerouslySetInnerHTML to render syntax-highlighted YAML. But the content from the server isn't being escaped before injection — which means any HTML-like characters in the YAML values (like in annotations or labels) could get executed as real HTML/JS in the browser.

Interestingly, PodGroups.jsx already handles this correctly using lodash.escape(), but the other three pages don't. This PR fixes that inconsistency.

**What's the fix?**
Added lodash.escape() to sanitize all YAML keys, values, and raw lines before they get wrapped in HTML — same pattern that PodGroups.jsx already uses.

**Files changed:**

- frontend/src/components/jobs/Jobs.jsx
- frontend/src/components/pods/Pods.jsx
- frontend/src/components/queues/Queues.jsx

**How to verify**
Look at the diff — ${key} becomes ${escape(key)}, ${value} becomes ${escape(value)}, and plain lines go through escape(line). This converts characters like <, >, " into safe HTML entities (&lt;, &gt;, &quot;) so they render as text instead of being parsed as HTML.