### PR TITLE
fix: resolve pods pagination breaking after create

### DIFF
--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -86,17 +86,6 @@ const Pods = () => {
         fetchPods();
     }, [fetchPods]);
 
-    const fetchData = async () => {
-        try {
-            const response = await fetch("/api/pods");
-            if (response.ok) {
-                const data = await response.json();
-                setPods(data);
-            }
-        } catch (error) {
-            console.error("Error fetching pods:", error);
-        }
-    };
 
     const handleCreatePod = async (newPod) => {
         try {
@@ -119,7 +108,8 @@ const Pods = () => {
             }
 
             alert("Pod created successfully!");
-            await fetchData(); // Now fetchData is defined in the same scope
+            setPagination((prev) => ({ ...prev, page: 1 }));
+            await fetchPods();
         } catch (err) {
             alert("Network error: " + err.message);
         }


### PR DESCRIPTION
Fix #226 
pagination break bug in Pod table. Remove `fetchData()` function. Change `handleCreatePod` to call `fetchPods()`. Now table show correct page after Pod create.