### PR TITLE
fix: remove duplicate API call on search clear in Jobs

### DIFF
--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -86,7 +86,6 @@ const Jobs = () => {
     const handleClearSearch = () => {
         setSearchText("");
         setPagination((prev) => ({ ...prev, page: 1 }));
-        fetchJobs();
     };
 
     const handleJobClick = useCallback(async (job) => {


### PR DESCRIPTION
fixes #228 
Removed the redundant manual `fetchJobs()` call inside `handleClearSearch`.  As Clearing `searchText` already triggers a re-fetch via the existing useEffect , `fetchJobs` dependency chain, so the explicit call results in duplicate `/api/jobs` requests on every search clear.