### PR TITLE
refactor: replace hardcoded color values with theme variable

### DIFF
--- a/frontend/src/components/CreateDialog.jsx
+++ b/frontend/src/components/CreateDialog.jsx
@@ -16,8 +16,7 @@ import {
 } from "@mui/material";
 import { Button } from "react-bootstrap";
 import { Plus, Minus, ChevronDown } from "lucide-react";
-
-const primaryColor = "#E34C26";
+import { volcanoOrange as primaryColor } from "../theme";
 
 const CreateDialog = ({
     open,

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -22,14 +22,13 @@ import CategoryIcon from "@mui/icons-material/Category";
 
 // use relative path to load Logo
 import volcanoLogo from "../assets/volcano-icon-color.svg";
+import { volcanoOrange } from "../theme";
 
 const Layout = () => {
     // Hooks must be used inside component functions
     const location = useLocation();
     const [open, setOpen] = useState(true);
 
-    // constants can be kept outside the component
-    const volcanoOrange = "#E34C26"; // orange red theme
     const headerGrey = "#424242"; // dark gray top stripe
     const drawerWidth = 240;
 

--- a/frontend/src/components/Searchbar.jsx
+++ b/frontend/src/components/Searchbar.jsx
@@ -13,6 +13,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faSearch, faTimes, faRedo } from "@fortawesome/free-solid-svg-icons";
 import CreateDialog from "./CreateDialog";
 import CreateJobDialog from "./jobs/JobTable/CreateJobDialog";
+import { volcanoOrange } from "../theme";
 
 const SearchBar = ({
     searchText,
@@ -66,7 +67,7 @@ const SearchBar = ({
                                         <FontAwesomeIcon
                                             icon={faSearch}
                                             className="me-1"
-                                            style={{ color: "#E34C26" }}
+                                            style={{ color: volcanoOrange }}
                                         />
                                         {isRefreshing && (
                                             <span
@@ -113,7 +114,7 @@ const SearchBar = ({
                                     onClick={handleRefresh}
                                     disabled={isRefreshing}
                                     style={{
-                                        backgroundColor: "#E34C26",
+                                        backgroundColor: volcanoOrange,
                                         color: "white",
                                         transition: "all 0.3s ease",
                                         height: "35px",
@@ -138,7 +139,7 @@ const SearchBar = ({
                                     className="rounded-pill px-4 py-2 d-flex align-items-center justify-content-center shadow-sm fw-medium border-2"
                                     onClick={handleOpenDialog}
                                     style={{
-                                        backgroundColor: "#E34C26",
+                                        backgroundColor: volcanoOrange,
                                         color: "white",
                                         transition: "all 0.3s ease",
                                         height: "35px",

--- a/frontend/src/components/jobs/JobTable/CreateJobDialog.jsx
+++ b/frontend/src/components/jobs/JobTable/CreateJobDialog.jsx
@@ -10,8 +10,7 @@ import {
 import { Button } from "react-bootstrap";
 import Editor from "@monaco-editor/react";
 import yaml from "js-yaml";
-
-const primaryColor = "#E34C26";
+import { volcanoOrange as primaryColor } from "../../../theme";
 
 const CreateJobDialog = ({
     open,


### PR DESCRIPTION
### Description

The same brand color (#E34C26) was being used in multiple components with hardcoded values instead of using the shared volcanoOrange color from theme.js.

### Changes made

Replaced all 7 hardcoded #E34C26 values with the shared volcanoOrange variable from src/theme.js.

**Updated files:**

- Layout.jsx
- CreateDialog.jsx
- CreateJobDialog.jsx
- Searchbar.jsx
- Why this change

### Why this change

- This makes the code easier to maintain and keeps the styling consistent across the app.
- Now if the brand color ever changes, it only needs to be updated in one place instead of multiple files.

### Verification

- prettier --check passing
- eslint passing with 0 errors and 0 warnings
- All unit tests passing
- No visual changes since the same color value is still being used