### PR TITLE
feat(i18n): introduce react-i18next and add zh-CN sidebar translations

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
         "bootstrap": "^5.3.5",
         "chart.js": "^4.4.7",
         "dotenv": "^16.4.7",
+        "i18next": "^25.4.2",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.511.0",
@@ -32,6 +33,7 @@
         "react-bootstrap": "^2.10.9",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
+        "react-i18next": "^15.7.3",
         "react-router-dom": "^7.1.5"
     },
     "devDependencies": {

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -13,6 +13,7 @@ import {
     Typography,
     Tooltip,
 } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import MenuIcon from "@mui/icons-material/Menu";
 import CloudIcon from "@mui/icons-material/Cloud";
 import HomeIcon from "@mui/icons-material/Home";
@@ -24,6 +25,8 @@ import CategoryIcon from "@mui/icons-material/Category";
 import volcanoLogo from "../assets/volcano-icon-color.svg";
 
 const Layout = () => {
+    const { t } = useTranslation();
+
     // Hooks must be used inside component functions
     const location = useLocation();
     const [open, setOpen] = useState(true);
@@ -38,11 +41,36 @@ const Layout = () => {
     };
 
     const menuItems = [
-        { text: "Dashboard", icon: <HomeIcon />, path: "/dashboard" },
-        { text: "Jobs", icon: <AssignmentIcon />, path: "/jobs" },
-        { text: "Queues", icon: <CloudIcon />, path: "/queues" },
-        { text: "Pods", icon: <WorkspacesIcon />, path: "/pods" },
-        { text: "PodGroups", icon: <CategoryIcon />, path: "/podgroups" },
+        {
+            id: "dashboard",
+            labelKey: "nav.dashboard",
+            icon: <HomeIcon />,
+            path: "/dashboard",
+        },
+        {
+            id: "jobs",
+            labelKey: "nav.jobs",
+            icon: <AssignmentIcon />,
+            path: "/jobs",
+        },
+        {
+            id: "queues",
+            labelKey: "nav.queues",
+            icon: <CloudIcon />,
+            path: "/queues",
+        },
+        {
+            id: "pods",
+            labelKey: "nav.pods",
+            icon: <WorkspacesIcon />,
+            path: "/pods",
+        },
+        {
+            id: "podgroups",
+            labelKey: "nav.podGroups",
+            icon: <CategoryIcon />,
+            path: "/podgroups",
+        },
     ];
 
     return (
@@ -73,7 +101,7 @@ const Layout = () => {
                             fontWeight: 500,
                         }}
                     >
-                        Volcano Dashboard
+                        {t("app.title")}
                     </Typography>
                 </Toolbar>
             </AppBar>
@@ -99,9 +127,10 @@ const Layout = () => {
                 <Box sx={{ overflow: "hidden auto", flexGrow: 1 }}>
                     <List>
                         {menuItems.map((item) => {
+                            const label = t(item.labelKey);
                             const listItem = (
                                 <ListItem
-                                    key={item.text}
+                                    key={item.id}
                                     component={Link}
                                     to={item.path}
                                     className={
@@ -128,20 +157,20 @@ const Layout = () => {
                                 >
                                     <ListItemIcon>{item.icon}</ListItemIcon>
                                     {open && (
-                                        <ListItemText primary={item.text} />
+                                        <ListItemText primary={label} />
                                     )}
                                 </ListItem>
                             );
                             return !open ? (
                                 <Tooltip
-                                    key={item.text}
-                                    title={item.text}
+                                    key={item.id}
+                                    title={label}
                                     placement="right"
                                 >
                                     {listItem}
                                 </Tooltip>
                             ) : (
-                                <React.Fragment key={item.text}>
+                                <React.Fragment key={item.id}>
                                     {listItem}
                                 </React.Fragment>
                             );

--- a/frontend/src/i18n/index.js
+++ b/frontend/src/i18n/index.js
@@ -1,0 +1,36 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+
+import enTranslation from "./locales/en/translation.json";
+import zhCNTranslation from "./locales/zh-CN/translation.json";
+
+const detectDefaultLanguage = () => {
+    const envLang = import.meta.env?.VITE_DEFAULT_LANG;
+    if (typeof envLang === "string" && envLang.trim()) {
+        return envLang.trim();
+    }
+
+    if (typeof navigator !== "undefined") {
+        const lang = navigator.language || navigator.userLanguage;
+        if (typeof lang === "string" && lang.toLowerCase().startsWith("zh")) {
+            return "zh-CN";
+        }
+    }
+
+    return "en";
+};
+
+i18n.use(initReactI18next).init({
+    resources: {
+        en: { translation: enTranslation },
+        "zh-CN": { translation: zhCNTranslation },
+    },
+    lng: detectDefaultLanguage(),
+    fallbackLng: "en",
+    showSupportNotice: false,
+    interpolation: {
+        escapeValue: false,
+    },
+});
+
+export default i18n;

--- a/frontend/src/i18n/locales/en/translation.json
+++ b/frontend/src/i18n/locales/en/translation.json
@@ -1,0 +1,12 @@
+{
+    "app": {
+        "title": "Volcano Dashboard"
+    },
+    "nav": {
+        "dashboard": "Dashboard",
+        "jobs": "Jobs",
+        "queues": "Queues",
+        "pods": "Pods",
+        "podGroups": "PodGroups"
+    }
+}

--- a/frontend/src/i18n/locales/zh-CN/translation.json
+++ b/frontend/src/i18n/locales/zh-CN/translation.json
@@ -1,0 +1,12 @@
+{
+    "app": {
+        "title": "Volcano 仪表盘"
+    },
+    "nav": {
+        "dashboard": "仪表盘",
+        "jobs": "作业",
+        "queues": "队列",
+        "pods": "Pod",
+        "podGroups": "Pod 组"
+    }
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,15 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { I18nextProvider } from "react-i18next";
 import "./index.css";
 import App from "./App.jsx";
 
+import i18n from "./i18n";
+
 createRoot(document.getElementById("root")).render(
     <StrictMode>
-        <App />
+        <I18nextProvider i18n={i18n}>
+            <App />
+        </I18nextProvider>
     </StrictMode>,
 );

--- a/frontend/tests/Layout.test.jsx
+++ b/frontend/tests/Layout.test.jsx
@@ -1,6 +1,8 @@
 import Layout from "../src/components/Layout";
 import { MemoryRouter } from "react-router-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import i18n from "../src/i18n";
 
 const menuItems = [
     { text: "Dashboard", path: "/dashboard" },
@@ -11,11 +13,17 @@ const menuItems = [
 ];
 
 describe("Layout", () => {
+    beforeEach(async () => {
+        await i18n.changeLanguage("en");
+    });
+
     it("should render the layout", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nextProvider i18n={i18n}>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nextProvider>,
         );
 
         const heading = screen.getByText(/volcano dashboard/i);
@@ -24,9 +32,11 @@ describe("Layout", () => {
 
     it("should toggle the drawer when clicking the menu button", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nextProvider i18n={i18n}>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nextProvider>,
         );
 
         const menuButton = screen.getByRole("button", {
@@ -46,9 +56,11 @@ describe("Layout", () => {
 
     it("should have 5 navigation items", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nextProvider i18n={i18n}>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nextProvider>,
         );
 
         const navigationItems = screen.getAllByRole("link");
@@ -65,9 +77,11 @@ describe("Layout", () => {
 
     it("should render logo", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nextProvider i18n={i18n}>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nextProvider>,
         );
 
         const logo = screen.getByAltText(/volcano logo/i);

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,7 @@
                 "bootstrap": "^5.3.5",
                 "chart.js": "^4.4.7",
                 "dotenv": "^16.4.7",
+                "i18next": "^25.4.2",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
                 "lucide-react": "^0.511.0",
@@ -96,6 +97,7 @@
                 "react-bootstrap": "^2.10.9",
                 "react-chartjs-2": "^5.3.0",
                 "react-dom": "^19.0.0",
+                "react-i18next": "^15.7.3",
                 "react-router-dom": "^7.1.5"
             },
             "devDependencies": {
@@ -1966,9 +1968,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -7892,6 +7894,15 @@
                 "node": ">=18"
             }
         },
+        "node_modules/html-parse-stringify": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+            "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+            "license": "MIT",
+            "dependencies": {
+                "void-elements": "3.1.0"
+            }
+        },
         "node_modules/http-errors": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7964,6 +7975,38 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
+            }
+        },
+        "node_modules/i18next": {
+            "version": "25.10.10",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-25.10.10.tgz",
+            "integrity": "sha512-cqUW2Z3EkRx7NqSyywjkgCLK7KLCL6IFVFcONG7nVYIJ3ekZ1/N5jUsihHV6Bq37NfhgtczxJcxduELtjTwkuQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com/i18next"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "@babel/runtime": "^7.29.2"
+            },
+            "peerDependencies": {
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/iconv-lite": {
@@ -10624,6 +10667,32 @@
                 "react": "^19.2.3"
             }
         },
+        "node_modules/react-i18next": {
+            "version": "15.7.4",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.7.4.tgz",
+            "integrity": "sha512-nyU8iKNrI5uDJch0z9+Y5XEr34b0wkyYj3Rp+tfbahxtlswxSCjcUL9H0nqXo9IR3/t5Y5PKIA3fx3MfUyR9Xw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.27.6",
+                "html-parse-stringify": "^3.0.1"
+            },
+            "peerDependencies": {
+                "i18next": ">= 23.4.0",
+                "react": ">= 16.8.0",
+                "typescript": "^5"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-is": {
             "version": "19.2.3",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.3.tgz",
@@ -12524,7 +12593,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -12959,6 +13028,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/void-elements": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+            "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/volcano-dashboard-app": {


### PR DESCRIPTION
## Context
This PR addresses the prerequisite “translate a UI section into Chinese” in a scalable way by introducing a standard i18n layer (i18next + react-i18next) and translating a single, high-visibility UI section: the global app chrome (header title + sidebar).

## What changed
- Added i18n initialization and language detection:
  - [frontend/src/i18n/index.js](frontend/src/i18n/index.js)
  - Defaults to `VITE_DEFAULT_LANG` if set, else uses browser language (zh* → zh-CN), else falls back to `en`
- Added locale resources:
  - [frontend/src/i18n/locales/en/translation.json](frontend/src/i18n/locales/en/translation.json)
  - [frontend/src/i18n/locales/zh-CN/translation.json](frontend/src/i18n/locales/zh-CN/translation.json)
- Wired i18n at app entry:
  - [frontend/src/main.jsx](frontend/src/main.jsx)
- Replaced hardcoded sidebar/header labels with translation keys:
  - [frontend/src/components/Layout.jsx](frontend/src/components/Layout.jsx)
- Updated unit tests to render Layout under I18nextProvider (tests pinned to `en` for stable assertions):
  - [frontend/tests/Layout.test.jsx](frontend/tests/Layout.test.jsx)

## Why this approach
- Moves hardcoded UI labels behind stable keys (`app.title`, `nav.*`) so additional pages can be translated incrementally without duplicating strings.
- Keeps translations reusable if/when the frontend moves from React/Vite to Next.js:
  - The key/value resources (JSON) and the `t("...")` calls remain the same.
  - Only the “wiring layer” changes (e.g., Next.js wrapper + SSR-aware i18n setup via next-i18next or an i18next + react-i18next App Router pattern).
- Maintains safe fallback behavior (missing keys fall back to English).

## How to test
- Unit tests:
  - `npm run test:frontend`
- Manual verification (force Chinese):
  - `VITE_DEFAULT_LANG=zh-CN npm run dev -w frontend`

## Notes
- This PR intentionally translates only the sidebar + header title to keep scope focused and reviewable while establishing a maintainable foundation for future translations.

Related Issue #197 

## Screenshots
- English
<img width="1408" height="853" alt="image" src="https://github.com/user-attachments/assets/1a0fc0d0-99da-470c-b6f1-3e0d0db724b1" />

- Chinesse
<img width="1415" height="860" alt="image" src="https://github.com/user-attachments/assets/b5f1b671-cdd6-41a4-99f7-9d70c87587e4" />
