### PR TITLE
fix(ui): auto-refresh job and queue lists after resource creation

### DIFF
--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -162,6 +162,7 @@ const Jobs = () => {
             }
 
             alert("Job created successfully!");
+            fetchJobs();
         } catch (err) {
             alert("Network error: " + err.message);
         }

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -71,6 +71,7 @@ const Queues = () => {
             }
 
             alert("Queue created successfully!");
+            await fetchQueues();
         } catch (err) {
             alert(
                 "Network error: " + (err?.response?.data?.error || err.message),


### PR DESCRIPTION
### What this PR does
Adds automatic data refresh after successfully creating a Job or Queue,
so users immediately see their new resource in the list without manually
clicking "Refresh".

- The Pods page (`Pods.jsx`) already calls `fetchData()` after creation.
### Changes
- `Jobs.jsx`: Call `fetchJobs()` after successful job creation
- `Queues.jsx`: Call `fetchQueues()` after successful queue creation