### PR TITLE
feat(i18n): translate Pods page UI strings to Chinese

### DIFF
--- a/frontend/src/components/pods/PodDetailsDialog.jsx
+++ b/frontend/src/components/pods/PodDetailsDialog.jsx
@@ -26,7 +26,7 @@ const PodDetailsDialog = ({ open, podName, podYaml, onClose }) => {
                 },
             }}
         >
-            <DialogTitle>Pod YAML - {podName}</DialogTitle>
+            <DialogTitle>Pod YAML 详情 - {podName}</DialogTitle>
             <DialogContent>
                 <Box
                     sx={{
@@ -75,7 +75,7 @@ const PodDetailsDialog = ({ open, podName, podYaml, onClose }) => {
                             },
                         }}
                     >
-                        Close
+                        关闭
                     </Button>
                 </Box>
             </DialogActions>

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -51,7 +51,7 @@ const Pods = () => {
             setCachedPods(data.items || []);
             setTotalPods(data.totalCount || 0);
         } catch (err) {
-            setError("Failed to fetch pods: " + err.message);
+            setError("获取 Pod 失败: " + err.message);
             setCachedPods([]);
         } finally {
             setLoading(false);
@@ -107,21 +107,21 @@ const Pods = () => {
             });
 
             if (!response.ok) {
-                let errorMsg = "Unknown error";
+                let errorMsg = "未知错误";
                 try {
                     const errData = await response.json();
                     errorMsg = errData.error || response.statusText;
                 } catch {
                     // ignore error
                 }
-                alert("Error creating pod: " + errorMsg);
+                alert("创建 Pod 出错: " + errorMsg);
                 return;
             }
 
-            alert("Pod created successfully!");
+            alert("Pod 创建成功！");
             await fetchData(); // Now fetchData is defined in the same scope
         } catch (err) {
-            alert("Network error: " + err.message);
+            alert("网络错误: " + err.message);
         }
     };
 
@@ -151,7 +151,7 @@ const Pods = () => {
             setOpenDialog(true);
         } catch (err) {
             console.error("Failed to fetch pod YAML:", err);
-            setError("Failed to fetch pod YAML: " + err.message);
+            setError("获取 Pod YAML 失败: " + err.message);
         } finally {
             setLoading(false);
         }
@@ -185,7 +185,7 @@ const Pods = () => {
                     <Typography variant="body1">{error}</Typography>
                 </Box>
             )}
-            <TitleComponent text="Volcano Pods Status" />
+            <TitleComponent text="Volcano Pod 状态" />
             <Box>
                 <SearchBar
                     searchText={searchText}
@@ -194,11 +194,11 @@ const Pods = () => {
                     handleRefresh={handleRefresh}
                     fetchData={fetchPods}
                     isRefreshing={false} // Update if needed
-                    placeholder="Search Pods..."
-                    refreshLabel="Refresh Pods"
-                    createlabel="Create Pod"
-                    dialogTitle="Create a Pod"
-                    dialogResourceNameLabel="Pod Name"
+                    placeholder="搜索 Pod..."
+                    refreshLabel="刷新 Pod"
+                    createlabel="创建 Pod"
+                    dialogTitle="创建 Pod"
+                    dialogResourceNameLabel="Pod 名称"
                     dialogResourceType="Pod"
                     onCreateClick={handleCreatePod}
                 />

--- a/frontend/src/components/pods/PodsPagination.jsx
+++ b/frontend/src/components/pods/PodsPagination.jsx
@@ -24,9 +24,9 @@ const PodsPagination = ({ totalPods, pagination, onPaginationChange }) => {
                 onChange={handleChangeRowsPerPage}
                 size="small"
             >
-                <MenuItem value={5}>5 per page</MenuItem>
-                <MenuItem value={10}>10 per page</MenuItem>
-                <MenuItem value={20}>20 per page</MenuItem>
+                <MenuItem value={5}>5 条/页</MenuItem>
+                <MenuItem value={10}>10 条/页</MenuItem>
+                <MenuItem value={20}>20 条/页</MenuItem>
             </Select>
             <Box
                 sx={{
@@ -38,7 +38,7 @@ const PodsPagination = ({ totalPods, pagination, onPaginationChange }) => {
                 }}
             >
                 <Typography variant="body2" sx={{ mr: 2 }}>
-                    Total Pods: {totalPods}
+                    Pod 总数: {totalPods}
                 </Typography>
                 <Pagination
                     count={Math.ceil(totalPods / pagination.rowsPerPage)}

--- a/frontend/src/components/pods/PodsTable/FilterMenu.jsx
+++ b/frontend/src/components/pods/PodsTable/FilterMenu.jsx
@@ -1,18 +1,36 @@
 import React from "react";
 import { Menu, MenuItem } from "@mui/material";
 
-const FilterMenu = ({ anchorEl, handleClose, items, filterType }) => (
-    <Menu
-        anchorEl={anchorEl}
-        open={Boolean(anchorEl)}
-        onClose={() => handleClose(filterType, null)}
-    >
-        {items.map((item) => (
-            <MenuItem key={item} onClick={() => handleClose(filterType, item)}>
-                {item}
-            </MenuItem>
-        ))}
-    </Menu>
-);
+const STATUS_LABELS_TO_VALUES = {
+    全部: "All",
+    运行中: "Running",
+    等待中: "Pending",
+    已成功: "Succeeded",
+    已失败: "Failed",
+};
+
+const FilterMenu = ({ anchorEl, handleClose, items, filterType }) => {
+    const onMenuItemClick = (item) => {
+        const value =
+            filterType === "status" && STATUS_LABELS_TO_VALUES[item]
+                ? STATUS_LABELS_TO_VALUES[item]
+                : item;
+        handleClose(filterType, value);
+    };
+
+    return (
+        <Menu
+            anchorEl={anchorEl}
+            open={Boolean(anchorEl)}
+            onClose={() => handleClose(filterType, null)}
+        >
+            {items.map((item) => (
+                <MenuItem key={item} onClick={() => onMenuItemClick(item)}>
+                    {item}
+                </MenuItem>
+            ))}
+        </Menu>
+    );
+};
 
 export default FilterMenu;

--- a/frontend/src/components/pods/PodsTable/PodRow.jsx
+++ b/frontend/src/components/pods/PodsTable/PodRow.jsx
@@ -62,7 +62,17 @@ const PodRow = ({ pod, getStatusColor, onPodClick }) => {
 
             <TableCell sx={{ padding: "16px 24px" }}>
                 <Chip
-                    label={pod.status?.phase || "Unknown"}
+                    label={(() => {
+                        const phase = pod.status?.phase || "Unknown";
+                        const phaseMap = {
+                            Running: "运行中",
+                            Succeeded: "已成功",
+                            Failed: "已失败",
+                            Pending: "等待中",
+                            Unknown: "未知",
+                        };
+                        return phaseMap[phase] || phase;
+                    })()}
                     sx={{
                         bgcolor: getStatusColor(pod.status?.phase || "Unknown"),
                         color: "common.white",

--- a/frontend/src/components/pods/PodsTable/PodsTable.jsx
+++ b/frontend/src/components/pods/PodsTable/PodsTable.jsx
@@ -3,7 +3,10 @@ import {
     TableContainer,
     Table,
     TableBody,
+    TableCell,
+    TableRow,
     Paper,
+    Typography,
     useTheme,
     alpha,
 } from "@mui/material";
@@ -120,14 +123,28 @@ const PodsTable = ({
                     sortDirection={sortDirection}
                 />
                 <TableBody>
-                    {sortedPods.map((pod) => (
-                        <PodRow
-                            key={`${pod.metadata.namespace}-${pod.metadata.name}`}
-                            pod={pod}
-                            getStatusColor={getStatusColor}
-                            onPodClick={onPodClick}
-                        />
-                    ))}
+                    {sortedPods.length === 0 ? (
+                        <TableRow>
+                            <TableCell
+                                colSpan={5}
+                                align="center"
+                                sx={{ py: 8, color: "text.secondary" }}
+                            >
+                                <Typography variant="body1">
+                                    暂无数据
+                                </Typography>
+                            </TableCell>
+                        </TableRow>
+                    ) : (
+                        sortedPods.map((pod) => (
+                            <PodRow
+                                key={`${pod.metadata.namespace}-${pod.metadata.name}`}
+                                pod={pod}
+                                getStatusColor={getStatusColor}
+                                onPodClick={onPodClick}
+                            />
+                        ))
+                    )}
                 </TableBody>
             </Table>
         </TableContainer>

--- a/frontend/src/components/pods/PodsTable/TableHeader.jsx
+++ b/frontend/src/components/pods/PodsTable/TableHeader.jsx
@@ -16,6 +16,22 @@ import {
 } from "@mui/icons-material";
 import FilterMenu from "./FilterMenu";
 
+const HEADERS = [
+    { label: "名称", key: "name" },
+    { label: "命名空间", key: "namespace" },
+    { label: "创建时间", key: "creationTime" },
+    { label: "状态", key: "status" },
+    { label: "时长", key: "age" },
+];
+
+const STATUS_OPTIONS = [
+    { label: "全部", value: "All" },
+    { label: "运行中", value: "Running" },
+    { label: "等待中", value: "Pending" },
+    { label: "已成功", value: "Succeeded" },
+    { label: "已失败", value: "Failed" },
+];
+
 const TableHeader = ({
     filters,
     anchorEl,
@@ -27,135 +43,129 @@ const TableHeader = ({
 }) => {
     const theme = useTheme();
 
+    const getStatusLabel = (value) => {
+        const found = STATUS_OPTIONS.find((o) => o.value === value);
+        return found ? found.label : value;
+    };
+
     return (
         <TableHead>
             <TableRow>
-                {["Name", "Namespace", "Creation Time", "Status", "Age"].map(
-                    (header) => (
-                        <TableCell
-                            key={header}
-                            sx={{
-                                backgroundColor: alpha(
-                                    theme.palette.background.paper,
-                                    0.8,
-                                ),
-                                backdropFilter: "blur(8px)",
-                                padding: "16px 24px",
-                                minWidth: 140,
-                                borderBottom: `2px solid ${alpha(
-                                    theme.palette.primary.main,
-                                    0.2,
-                                )}`,
-                            }}
+                {HEADERS.map((h) => (
+                    <TableCell
+                        key={h.key}
+                        sx={{
+                            backgroundColor: alpha(
+                                theme.palette.background.paper,
+                                0.8,
+                            ),
+                            backdropFilter: "blur(8px)",
+                            padding: "16px 24px",
+                            minWidth: 140,
+                            borderBottom: `2px solid ${alpha(
+                                theme.palette.primary.main,
+                                0.2,
+                            )}`,
+                        }}
+                    >
+                        <Typography
+                            variant="subtitle1"
+                            fontWeight="700"
+                            color="text.primary"
+                            sx={{ letterSpacing: "0.02em" }}
                         >
-                            <Typography
-                                variant="subtitle1"
-                                fontWeight="700"
-                                color="text.primary"
-                                sx={{ letterSpacing: "0.02em" }}
-                            >
-                                {header}
-                            </Typography>
-                            {(header === "Namespace" ||
-                                header === "Status") && (
-                                <Button
-                                    size="small"
-                                    startIcon={<FilterList fontSize="small" />}
-                                    onClick={(e) =>
-                                        handleFilterClick(
-                                            header.toLowerCase(),
-                                            e,
-                                        )
-                                    }
-                                    sx={{
-                                        textTransform: "none",
-                                        padding: "4px 12px",
-                                        minWidth: "auto",
-                                        borderRadius: "20px",
-                                        marginTop: "8px",
-                                        fontSize: "0.8rem",
-                                        fontWeight: 500,
-                                        letterSpacing: "0.02em",
-                                        transition:
-                                            "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
-                                        backgroundColor:
-                                            filters[header.toLowerCase()] !==
-                                            "All"
-                                                ? alpha(
-                                                      theme.palette.primary
-                                                          .main,
-                                                      0.2,
-                                                  )
-                                                : alpha(
-                                                      theme.palette.primary
-                                                          .main,
-                                                      0.1,
-                                                  ),
-                                        color: theme.palette.primary.main,
-                                        "&:hover": {
-                                            backgroundColor: alpha(
-                                                theme.palette.primary.main,
-                                                0.15,
-                                            ),
-                                            transform: "translateY(-2px)",
-                                            boxShadow: `0 4px 8px ${alpha(
-                                                theme.palette.primary.main,
-                                                0.2,
-                                            )}`,
-                                        },
-                                    }}
-                                >
-                                    Filter: {filters[header.toLowerCase()]}
-                                </Button>
-                            )}
-                            {header === "Creation Time" && (
-                                <Button
-                                    size="small"
-                                    onClick={onSortDirectionToggle}
-                                    startIcon={
-                                        sortDirection === "desc" ? (
-                                            <ArrowDownward fontSize="small" />
-                                        ) : sortDirection === "asc" ? (
-                                            <ArrowUpward fontSize="small" />
-                                        ) : (
-                                            <UnfoldMore fontSize="small" />
-                                        )
-                                    }
-                                    sx={{
-                                        textTransform: "none",
-                                        padding: "4px 12px",
-                                        minWidth: "auto",
-                                        borderRadius: "20px",
-                                        marginTop: "8px",
-                                        fontSize: "0.8rem",
-                                        fontWeight: 500,
-                                        letterSpacing: "0.02em",
-                                        transition:
-                                            "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+                            {h.label}
+                        </Typography>
+                        {(h.key === "namespace" || h.key === "status") && (
+                            <Button
+                                size="small"
+                                startIcon={<FilterList fontSize="small" />}
+                                onClick={(e) => handleFilterClick(h.key, e)}
+                                sx={{
+                                    textTransform: "none",
+                                    padding: "4px 12px",
+                                    minWidth: "auto",
+                                    borderRadius: "20px",
+                                    marginTop: "8px",
+                                    fontSize: "0.8rem",
+                                    fontWeight: 500,
+                                    letterSpacing: "0.02em",
+                                    transition:
+                                        "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+                                    backgroundColor:
+                                        filters[h.key] !== "All"
+                                            ? alpha(
+                                                  theme.palette.primary.main,
+                                                  0.2,
+                                              )
+                                            : alpha(
+                                                  theme.palette.primary.main,
+                                                  0.1,
+                                              ),
+                                    color: theme.palette.primary.main,
+                                    "&:hover": {
                                         backgroundColor: alpha(
                                             theme.palette.primary.main,
-                                            0.1,
+                                            0.15,
                                         ),
-                                        color: theme.palette.primary.main,
-                                        "&:hover": {
-                                            backgroundColor: alpha(
-                                                theme.palette.primary.main,
-                                                0.15,
-                                            ),
-                                            transform: "translateY(-2px)",
-                                            boxShadow: `0 4px 8px ${alpha(
-                                                theme.palette.primary.main,
-                                                0.2,
-                                            )}`,
-                                        },
-                                    }}
-                                >
-                                    Sort
-                                </Button>
-                            )}
-                        </TableCell>
-                    ),
-                )}
+                                        transform: "translateY(-2px)",
+                                        boxShadow: `0 4px 8px ${alpha(
+                                            theme.palette.primary.main,
+                                            0.2,
+                                        )}`,
+                                    },
+                                }}
+                            >
+                                筛选: {getStatusLabel(filters[h.key])}
+                            </Button>
+                        )}
+                        {h.key === "creationTime" && (
+                            <Button
+                                size="small"
+                                onClick={onSortDirectionToggle}
+                                startIcon={
+                                    sortDirection === "desc" ? (
+                                        <ArrowDownward fontSize="small" />
+                                    ) : sortDirection === "asc" ? (
+                                        <ArrowUpward fontSize="small" />
+                                    ) : (
+                                        <UnfoldMore fontSize="small" />
+                                    )
+                                }
+                                sx={{
+                                    textTransform: "none",
+                                    padding: "4px 12px",
+                                    minWidth: "auto",
+                                    borderRadius: "20px",
+                                    marginTop: "8px",
+                                    fontSize: "0.8rem",
+                                    fontWeight: 500,
+                                    letterSpacing: "0.02em",
+                                    transition:
+                                        "all 0.3s cubic-bezier(0.4, 0, 0.2, 1)",
+                                    backgroundColor: alpha(
+                                        theme.palette.primary.main,
+                                        0.1,
+                                    ),
+                                    color: theme.palette.primary.main,
+                                    "&:hover": {
+                                        backgroundColor: alpha(
+                                            theme.palette.primary.main,
+                                            0.15,
+                                        ),
+                                        transform: "translateY(-2px)",
+                                        boxShadow: `0 4px 8px ${alpha(
+                                            theme.palette.primary.main,
+                                            0.2,
+                                        )}`,
+                                    },
+                                }}
+                            >
+                                排序
+                            </Button>
+                        )}
+                    </TableCell>
+                ))}
             </TableRow>
             <FilterMenu
                 anchorEl={anchorEl.namespace}
@@ -166,7 +176,7 @@ const TableHeader = ({
             <FilterMenu
                 anchorEl={anchorEl.status}
                 handleClose={handleFilterClose}
-                items={["All", "Running", "Pending", "Succeeded", "Failed"]}
+                items={STATUS_OPTIONS.map((o) => o.label)}
                 filterType="status"
             />
         </TableHead>

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,7 +307,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -2107,7 +2106,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2131,7 +2129,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2899,6 +2896,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
             "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2980,6 +2978,7 @@
             "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
@@ -3009,7 +3008,8 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
@@ -3306,7 +3306,6 @@
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
             "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.26.0",
                 "@mui/core-downloads-tracker": "^6.5.0",
@@ -3603,7 +3602,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -4090,7 +4088,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -4300,7 +4297,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -4311,7 +4307,6 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -4339,7 +4334,8 @@
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/warning": {
             "version": "3.0.3",
@@ -4506,7 +4502,8 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.7.0",
@@ -4535,7 +4532,6 @@
             "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/user-event": "^14.6.1",
@@ -4722,7 +4718,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5397,7 +5392,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5580,7 +5574,6 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -6270,6 +6263,7 @@
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
             "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
+            "peer": true,
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -6821,6 +6815,7 @@
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -6845,6 +6840,7 @@
             "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -6855,6 +6851,7 @@
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -6868,6 +6865,7 @@
             "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -6885,6 +6883,7 @@
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -6898,6 +6897,7 @@
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -6916,6 +6916,7 @@
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -6929,6 +6930,7 @@
             "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.3",
@@ -6944,6 +6946,7 @@
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -7489,7 +7492,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -7752,7 +7754,8 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -8719,7 +8722,6 @@
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 10.16.0"
             }
@@ -9171,6 +9173,7 @@
             "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
             "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -10565,7 +10568,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10616,7 +10618,6 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -10946,6 +10947,7 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -12181,7 +12183,8 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
@@ -12238,7 +12241,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12422,6 +12424,7 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -12705,7 +12708,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -12837,7 +12839,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12851,7 +12852,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -13296,7 +13296,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
             "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },


### PR DESCRIPTION
## Summary

Translates the Pods page UI strings to Chinese as part of the LFX Mentorship prerequisite task (issue #197).

## Changes

| File | Translated Strings |
|------|-------------------|
| `Pods.jsx` | Page title (Volcano Pod 状态), search placeholder (搜索 Pod...), refresh label (刷新 Pod), create label (创建 Pod), dialog title/labels, error messages |
| `PodsPagination.jsx` | Per-page options (5 条/页, 10 条/页, 20 条/页), total label (Pod 总数) |
| `TableHeader.jsx` | Table headers (名称, 命名空间, 创建时间, 状态, 时长), filter label (筛选), sort button (排序) |
| `FilterMenu.jsx` | Status options with display/value mapping (全部, 运行中, 等待中, 已成功, 已失败) |
| `PodRow.jsx` | Status chips (运行中, 等待中, 已成功, 已失败, 未知) |
| `PodsTable.jsx` | Empty state (暂无数据) |
| `PodDetailsDialog.jsx` | Dialog title (Pod YAML 详情), Close button (关闭) |

## Approach

Inline Chinese string translation (consistent with PR #233 approach). Key implementation details:

- `HEADERS` constant array with `{ key, label }` pairs replaces hardcoded header strings, enabling clean key-based logic for filter/sort buttons
- `STATUS_OPTIONS` constant provides display-to-value mapping to preserve filter logic while showing Chinese labels
- `FilterMenu` handles the display-to-value conversion for status filter dropdown items
- Pod row status chips use a `phaseMap` to translate Kubernetes phase values to Chinese
- All filter state (`filters.status`, `filters.namespace`) remains in English to maintain compatibility with API params and existing filter logic

## Testing

- `npm run build` passes without errors
- `npm run format:check` passes on all modified pods component files
- ESLint passes with no errors on `frontend/src/components/pods/`

## Screenshots

Will be added after testing against a live cluster.

---

Ref: #197