### PR TITLE
feat(ui): inline Chinese translations for Pods section

### DIFF
--- a/frontend/src/components/pods/PodDetailsDialog.jsx
+++ b/frontend/src/components/pods/PodDetailsDialog.jsx
@@ -26,7 +26,7 @@ const PodDetailsDialog = ({ open, podName, podYaml, onClose }) => {
                 },
             }}
         >
-            <DialogTitle>Pod YAML - {podName}</DialogTitle>
+            <DialogTitle>Pod YAML 详情 - {podName}</DialogTitle>
             <DialogContent>
                 <Box
                     sx={{
@@ -75,7 +75,7 @@ const PodDetailsDialog = ({ open, podName, podYaml, onClose }) => {
                             },
                         }}
                     >
-                        Close
+                        关闭
                     </Button>
                 </Box>
             </DialogActions>

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -185,7 +185,7 @@ const Pods = () => {
                     <Typography variant="body1">{error}</Typography>
                 </Box>
             )}
-            <TitleComponent text="Volcano Pods Status" />
+            <TitleComponent text="Volcano Pod 状态" />
             <Box>
                 <SearchBar
                     searchText={searchText}
@@ -194,11 +194,11 @@ const Pods = () => {
                     handleRefresh={handleRefresh}
                     fetchData={fetchPods}
                     isRefreshing={false} // Update if needed
-                    placeholder="Search Pods..."
-                    refreshLabel="Refresh Pods"
-                    createlabel="Create Pod"
-                    dialogTitle="Create a Pod"
-                    dialogResourceNameLabel="Pod Name"
+                    placeholder="搜索 Pod..."
+                    refreshLabel="刷新 Pod"
+                    createlabel="创建 Pod"
+                    dialogTitle="创建 Pod"
+                    dialogResourceNameLabel="Pod 名称"
                     dialogResourceType="Pod"
                     onCreateClick={handleCreatePod}
                 />

--- a/frontend/src/components/pods/PodsPagination.jsx
+++ b/frontend/src/components/pods/PodsPagination.jsx
@@ -24,9 +24,9 @@ const PodsPagination = ({ totalPods, pagination, onPaginationChange }) => {
                 onChange={handleChangeRowsPerPage}
                 size="small"
             >
-                <MenuItem value={5}>5 per page</MenuItem>
-                <MenuItem value={10}>10 per page</MenuItem>
-                <MenuItem value={20}>20 per page</MenuItem>
+                <MenuItem value={5}>每页 5 条</MenuItem>
+                <MenuItem value={10}>每页 10 条</MenuItem>
+                <MenuItem value={20}>每页 20 条</MenuItem>
             </Select>
             <Box
                 sx={{
@@ -38,7 +38,7 @@ const PodsPagination = ({ totalPods, pagination, onPaginationChange }) => {
                 }}
             >
                 <Typography variant="body2" sx={{ mr: 2 }}>
-                    Total Pods: {totalPods}
+                    Pod 总数: {totalPods}
                 </Typography>
                 <Pagination
                     count={Math.ceil(totalPods / pagination.rowsPerPage)}

--- a/frontend/src/components/pods/PodsTable/FilterMenu.jsx
+++ b/frontend/src/components/pods/PodsTable/FilterMenu.jsx
@@ -9,7 +9,13 @@ const FilterMenu = ({ anchorEl, handleClose, items, filterType }) => (
     >
         {items.map((item) => (
             <MenuItem key={item} onClick={() => handleClose(filterType, item)}>
-                {item}
+                {{
+                    All: "全部",
+                    Running: "运行中",
+                    Pending: "等待中",
+                    Succeeded: "成功",
+                    Failed: "失败",
+                }[item] || item}
             </MenuItem>
         ))}
     </Menu>

--- a/frontend/src/components/pods/PodsTable/PodRow.jsx
+++ b/frontend/src/components/pods/PodsTable/PodRow.jsx
@@ -62,7 +62,16 @@ const PodRow = ({ pod, getStatusColor, onPodClick }) => {
 
             <TableCell sx={{ padding: "16px 24px" }}>
                 <Chip
-                    label={pod.status?.phase || "Unknown"}
+                    label={
+                        {
+                            Running: "运行中",
+                            Pending: "等待中",
+                            Succeeded: "成功",
+                            Failed: "失败",
+                        }[pod.status?.phase] ||
+                        pod.status?.phase ||
+                        "未知"
+                    }
                     sx={{
                         bgcolor: getStatusColor(pod.status?.phase || "Unknown"),
                         color: "common.white",

--- a/frontend/src/components/pods/PodsTable/TableHeader.jsx
+++ b/frontend/src/components/pods/PodsTable/TableHeader.jsx
@@ -54,7 +54,13 @@ const TableHeader = ({
                                 color="text.primary"
                                 sx={{ letterSpacing: "0.02em" }}
                             >
-                                {header}
+                                {{
+                                    Name: "名称",
+                                    Namespace: "命名空间",
+                                    "Creation Time": "创建时间",
+                                    Status: "状态",
+                                    Age: "存活时间",
+                                }[header] || header}
                             </Typography>
                             {(header === "Namespace" ||
                                 header === "Status") && (
@@ -105,7 +111,15 @@ const TableHeader = ({
                                         },
                                     }}
                                 >
-                                    Filter: {filters[header.toLowerCase()]}
+                                    筛选:{" "}
+                                    {{
+                                        All: "全部",
+                                        Running: "运行中",
+                                        Pending: "等待中",
+                                        Succeeded: "成功",
+                                        Failed: "失败",
+                                    }[filters[header.toLowerCase()]] ||
+                                        filters[header.toLowerCase()]}
                                 </Button>
                             )}
                             {header === "Creation Time" && (
@@ -150,7 +164,7 @@ const TableHeader = ({
                                         },
                                     }}
                                 >
-                                    Sort
+                                    排序
                                 </Button>
                             )}
                         </TableCell>


### PR DESCRIPTION
## Summary
 
Translates all user-facing strings in the **Pods** section to Chinese (Simplified) to fulfill the LFX Mentorship prerequisite task.
 
To avoid conflicting with the larger `react-i18next` architecture proposals under discussion (#234, #235), I used a strict inline-mapping approach — strings are mapped directly at the render layer (e.g., `{{ "Name": "名称" }[header] || header}`). No component logic, array structures, or `sx` styling blocks were modified. Internal state values and Kubernetes namespace names remain in English, preserving all existing filtering and sorting behavior.
 
## Files Changed
 
All changes are localized to `frontend/src/components/pods/`:
 
| File | What was translated |
|---|---|
| `Pods.jsx` | Page title, search placeholder, buttons |
| `PodsTable/TableHeader.jsx` | Column headers, sort buttons, filter labels |
| `PodsTable/FilterMenu.jsx` | Dropdown menu options |
| `PodsTable/PodRow.jsx` | Status chip labels |
| `PodsPagination.jsx` | Pagination text |
| `PodDetailsDialog.jsx` | Dialog title, close button |
 
## Screenshots
 
**Before (English)**
<img width="1887" height="1026" alt="image" src="https://github.com/user-attachments/assets/5fe6d76b-5f1b-4a95-adea-208430b2a308" />
 
**After (Chinese)**
<img width="1884" height="1022" alt="image" src="https://github.com/user-attachments/assets/4a78b180-7c50-406d-bb47-6aa1ead3c3cf" />

 
---
 
*Refs #197*
 