### PR TITLE
fix: implement Global Error Boundary to prevent application crashes

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,35 +5,42 @@ import {
     Routes,
     Navigate,
 } from "react-router-dom";
+
 import Layout from "./components/Layout";
 import Dashboard from "./components/dashboard/Dashboard";
 import Jobs from "./components/jobs/Jobs";
 import Queues from "./components/queues/Queues";
 import Pods from "./components/pods/Pods";
 import PodGroups from "./components/podgroups/PodGroups";
+
 import { ThemeProvider } from "@mui/material/styles";
 import { theme } from "./theme";
+
+import GlobalErrorBoundary from "./components/common/GlobalErrorBoundary";
+
 import "bootstrap/dist/css/bootstrap.min.css";
 
 function App() {
     return (
-        <ThemeProvider theme={theme}>
-            <Router>
-                <Routes>
-                    <Route path="/" element={<Layout />}>
-                        <Route
-                            index
-                            element={<Navigate to="/dashboard" replace />}
-                        />
-                        <Route path="dashboard" element={<Dashboard />} />
-                        <Route path="jobs" element={<Jobs />} />
-                        <Route path="queues" element={<Queues />} />
-                        <Route path="pods" element={<Pods />} />
-                        <Route path="podgroups" element={<PodGroups />} />
-                    </Route>
-                </Routes>
-            </Router>
-        </ThemeProvider>
+        <GlobalErrorBoundary>
+            <ThemeProvider theme={theme}>
+                <Router>
+                    <Routes>
+                        <Route path="/" element={<Layout />}>
+                            <Route
+                                index
+                                element={<Navigate to="/dashboard" replace />}
+                            />
+                            <Route path="dashboard" element={<Dashboard />} />
+                            <Route path="jobs" element={<Jobs />} />
+                            <Route path="queues" element={<Queues />} />
+                            <Route path="pods" element={<Pods />} />
+                            <Route path="podgroups" element={<PodGroups />} />
+                        </Route>
+                    </Routes>
+                </Router>
+            </ThemeProvider>
+        </GlobalErrorBoundary>
     );
 }
 

--- a/frontend/src/components/common/GlobalErrorBoundary.jsx
+++ b/frontend/src/components/common/GlobalErrorBoundary.jsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { Box, Typography, Button, Paper } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutline";
+import RefreshIcon from "@mui/icons-material/Refresh";
+
+class GlobalErrorBoundary extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = { hasError: false, error: null };
+    }
+
+    static getDerivedStateFromError(error) {
+        // Update state so the next render will show the fallback UI.
+        return { hasError: true, error };
+    }
+
+    componentDidCatch(error, errorInfo) {
+        // You can also log the error to an error reporting service here
+        console.error("Uncaught error:", error, errorInfo);
+    }
+
+    handleReset = () => {
+        window.location.reload();
+    };
+
+    render() {
+        if (this.state.hasError) {
+            // You can render any custom fallback UI
+            return (
+                <Box
+                    sx={{
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                        minHeight: "100vh",
+                        bgcolor: "grey.50",
+                        p: 3,
+                    }}
+                >
+                    <Paper
+                        elevation={3}
+                        sx={{
+                            p: 5,
+                            maxWidth: 500,
+                            textAlign: "center",
+                            borderRadius: 2,
+                        }}
+                    >
+                        <ErrorOutlineIcon sx={{ fontSize: 64, color: "error.main", mb: 2 }} />
+                        <Typography variant="h5" gutterBottom sx={{ fontWeight: 600 }}>
+                            Something went wrong
+                        </Typography>
+                        <Typography variant="body1" color="text.secondary" sx={{ mb: 4 }}>
+                            The dashboard encountered an unexpected error. This might be due to a temporary network issue or invalid data from the cluster.
+                        </Typography>
+                        
+                        <Button
+                            variant="contained"
+                            startIcon={<RefreshIcon />}
+                            onClick={this.handleReset}
+                            sx={{ textTransform: "none", px: 4, py: 1 }}
+                        >
+                            Reload Dashboard
+                        </Button>
+                        
+                        {process.env.NODE_ENV === "development" && (
+                            <Box sx={{ mt: 4, textAlign: "left" }}>
+                                <Typography variant="caption" sx={{ fontFamily: 'monospace', bgcolor: 'grey.100', p: 1, display: 'block', borderRadius: 1, color: 'error.dark' }}>
+                                    {this.state.error && this.state.error.toString()}
+                                </Typography>
+                            </Box>
+                        )}
+                    </Paper>
+                </Box>
+            );
+        }
+
+        return this.props.children;
+    }
+}
+
+export default GlobalErrorBoundary;


### PR DESCRIPTION
### Description

while exploring the codebase, I noticed that the dashboard didn't have a 'safety net' for runtime errors. Right now, if a component crashes (like from a bad API response or a data parsing issue), the whole screen just goes white.

I've added a Global Error Boundary to catch these unexpected crashes. Now, instead of a blank screen, users will see a professional 'Something went wrong' page with a quick reload button. This makes the dashboard much more resilient and reliable for production users.

### Changes made:

- Added a GlobalErrorBoundary component using Material UI.
- Wrapped the main App component to protect the entire application tree.
- Added a 'Reload' utility to help users recover quickly without a manual browser refresh.