### PR TITLE
fix: auto-refresh job and queue list after successful creation

### DIFF
--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -162,7 +162,8 @@ const Jobs = () => {
             }
 
             alert("Job created successfully!");
-            fetchJobs(); 
+            setPagination((prev) => ({ ...prev, page: 1 }));
+            fetchJobs();
         } catch (err) {
             alert("Network error: " + err.message);
         }

--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -162,6 +162,7 @@ const Jobs = () => {
             }
 
             alert("Job created successfully!");
+            fetchJobs(); 
         } catch (err) {
             alert("Network error: " + err.message);
         }

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -71,7 +71,8 @@ const Queues = () => {
             }
 
             alert("Queue created successfully!");
-            fetchQueues();
+            setPagination((prev) => ({ ...prev, page: 1 }));
+            await fetchQueues();
         } catch (err) {
             alert(
                 "Network error: " + (err?.response?.data?.error || err.message),

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -71,6 +71,7 @@ const Queues = () => {
             }
 
             alert("Queue created successfully!");
+            fetchQueues();
         } catch (err) {
             alert(
                 "Network error: " + (err?.response?.data?.error || err.message),


### PR DESCRIPTION
## Problem
When a user creates a new Job or Queue via the dashboard UI, the data grid does not automatically refresh to show the newly created resource. The user must manually click the "Refresh" button.

## Fixes:
#236 

## Fix
- Added `fetchJobs()` call after successful job creation in `Jobs.jsx`
- Added `fetchQueues()` call after successful queue creation in `Queues.jsx`

## Testing
- Created a Job via the dashboard list refreshes automatically 
- Created a Queue via the dashboard list refreshes automatically 