### PR TITLE
feat(i18n): Translate Dashboard UI into Simplified Chinese

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,8 @@
         "bootstrap": "^5.3.5",
         "chart.js": "^4.4.7",
         "dotenv": "^16.4.7",
+        "i18next": "^26.2.0",
+        "i18next-browser-languagedetector": "^8.2.1",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.511.0",
@@ -32,6 +34,7 @@
         "react-bootstrap": "^2.10.9",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
+        "react-i18next": "^17.0.8",
         "react-router-dom": "^7.1.5"
     },
     "devDependencies": {

--- a/frontend/src/components/Charts/JobStatusPieChart.jsx
+++ b/frontend/src/components/Charts/JobStatusPieChart.jsx
@@ -2,14 +2,37 @@ import React from "react";
 import { Box, Typography } from "@mui/material";
 import { Doughnut } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, Title } from "chart.js";
+import { useTranslation } from "react-i18next";
 
 ChartJS.register(ArcElement, Tooltip, Legend, Title);
 
 const JobStatusPieChart = ({ data }) => {
+    const { t } = useTranslation();
+
+    const statusItems = [
+        {
+            key: "completed",
+            label: t("dashboard.charts.jobStatus.status.completed"),
+            color: "#4caf50",
+        },
+        {
+            key: "running",
+            label: t("dashboard.charts.jobStatus.status.running"),
+            color: "#2196f3",
+        },
+        {
+            key: "failed",
+            label: t("dashboard.charts.jobStatus.status.failed"),
+            color: "#f44336",
+        },
+    ];
+
     if (!data || !Array.isArray(data)) {
         return (
             <Box sx={{ height: 300, width: "100%", position: "relative" }}>
-                <Typography>No data available</Typography>
+                <Typography>
+                    {t("dashboard.charts.jobStatus.noDataAvailable")}
+                </Typography>
             </Box>
         );
     }
@@ -18,37 +41,32 @@ const JobStatusPieChart = ({ data }) => {
         (acc, job) => {
             const status = job.status;
             if (status?.succeeded) {
-                acc.Completed++;
+                acc.completed++;
             } else if (
                 status?.state?.phase === "Running" ||
                 status?.state?.phase === "Pending"
             ) {
-                acc.Running++;
+                acc.running++;
             } else if (status?.state?.phase === "Failed") {
-                acc.Failed++;
+                acc.failed++;
             }
             return acc;
         },
         {
-            Completed: 0,
-            Running: 0,
-            Failed: 0,
+            completed: 0,
+            running: 0,
+            failed: 0,
         },
     );
 
     const total = Object.values(statusCounts).reduce((a, b) => a + b, 0);
-    const colors = {
-        Completed: "#4caf50",
-        Running: "#2196f3",
-        Failed: "#f44336",
-    };
 
     const chartData = {
-        labels: Object.keys(statusCounts),
+        labels: statusItems.map((status) => status.label),
         datasets: [
             {
-                data: Object.values(statusCounts),
-                backgroundColor: Object.values(colors),
+                data: statusItems.map((status) => statusCounts[status.key]),
+                backgroundColor: statusItems.map((status) => status.color),
                 borderColor: "white",
                 borderWidth: 2,
                 hoverBorderColor: "white",
@@ -80,7 +98,7 @@ const JobStatusPieChart = ({ data }) => {
             }}
         >
             <Typography variant="h6" align="center" sx={{ mb: 1 }}>
-                Jobs Status
+                {t("dashboard.charts.jobStatus.title")}
             </Typography>
 
             <Box
@@ -97,8 +115,8 @@ const JobStatusPieChart = ({ data }) => {
                 <Box
                     sx={{
                         flex: 1,
-                        minWidth: "250px", // Ensure that the chart is not too small
-                        height: "300px", // Fixed height to adapt to various screens
+                        minWidth: "250px",
+                        height: "300px",
                         position: "relative",
                         display: "flex",
                         alignItems: "center",
@@ -137,39 +155,46 @@ const JobStatusPieChart = ({ data }) => {
                         textAlign: "left",
                     }}
                 >
-                    {Object.entries(statusCounts).map(([status, count]) => (
-                        <Box
-                            key={status}
-                            sx={{
-                                display: "flex",
-                                alignItems: "center",
-                                mb: 1.5,
-                            }}
-                        >
+                    {statusItems.map((status) => {
+                        const count = statusCounts[status.key];
+
+                        return (
                             <Box
+                                key={status.key}
                                 sx={{
-                                    width: 12,
-                                    height: 12,
-                                    borderRadius: "50%",
-                                    backgroundColor: colors[status],
-                                    mr: 1,
+                                    display: "flex",
+                                    alignItems: "center",
+                                    mb: 1.5,
                                 }}
-                            />
-                            <Typography
-                                variant="body2"
-                                sx={{ mr: 2, minWidth: 70 }}
                             >
-                                {status}
-                            </Typography>
-                            <Typography variant="body2" color="text.secondary">
-                                {count} (
-                                {total > 0
-                                    ? ((count / total) * 100).toFixed(1)
-                                    : 0}
-                                %)
-                            </Typography>
-                        </Box>
-                    ))}
+                                <Box
+                                    sx={{
+                                        width: 12,
+                                        height: 12,
+                                        borderRadius: "50%",
+                                        backgroundColor: status.color,
+                                        mr: 1,
+                                    }}
+                                />
+                                <Typography
+                                    variant="body2"
+                                    sx={{ mr: 2, minWidth: 70 }}
+                                >
+                                    {status.label}
+                                </Typography>
+                                <Typography
+                                    variant="body2"
+                                    color="text.secondary"
+                                >
+                                    {count} (
+                                    {total > 0
+                                        ? ((count / total) * 100).toFixed(1)
+                                        : 0}
+                                    %)
+                                </Typography>
+                            </Box>
+                        );
+                    })}
                 </Box>
             </Box>
         </Box>

--- a/frontend/src/components/Charts/QueueResourcesBarChart.jsx
+++ b/frontend/src/components/Charts/QueueResourcesBarChart.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Box, FormControl, MenuItem, Select, Typography } from "@mui/material";
 import { Bar } from "react-chartjs-2";
 import "./chartConfig";
+import {useTranslation} from "react-i18next";
 
 const convertMemoryToGi = (memoryStr) => {
     if (!memoryStr) return 0;
@@ -53,7 +54,21 @@ const processData = (data) => {
     }, {});
 };
 
+const resourceTranslationKeys = {
+    memory : "memory",
+    cpu : "cpu",
+    pods : "pods",
+    "nvidia.com/gpu" : "gpu"
+}
+
+const getDefaultResourceLabel = (resource)=>{
+    return `${resource.charAt(0).toUpperCase() + resource.slice(1)} Resources`;
+}
+
 const QueueResourcesBarChart = ({ data }) => {
+
+    const { t } = useTranslation();
+
     const [selectedResource, setSelectedResource] = useState("");
 
     // Obtain resource type options dynamically
@@ -69,13 +84,15 @@ const QueueResourcesBarChart = ({ data }) => {
                 resourceTypes.add(resource),
             );
         });
-
+       
         // Convert resource type from Set to Array
         return Array.from(resourceTypes).map((resource) => ({
             value: resource,
-            label: `${resource.charAt(0).toUpperCase() + resource.slice(1)} Resources`,
+            label: resourceTranslationKeys[resource] 
+            ? t(`dashboard.charts.queueResources.resourceLabels.${resourceTranslationKeys[resource]}`)
+            : getDefaultResourceLabel(resource),
         }));
-    }, [data]);
+    }, [data, t]);
 
     useEffect(() => {
         // If there is a resource option, the first resource is selected by default
@@ -87,12 +104,30 @@ const QueueResourcesBarChart = ({ data }) => {
     // Process queue data
     const processedData = useMemo(() => processData(data), [data]);
 
+
+    const getResourceLabel = (resource) => {
+        switch (resource) {
+            case "memory":
+                return t("dashboard.charts.queueResources.resourceNames.memory");
+            case "cpu":
+                return t("dashboard.charts.queueResources.resourceNames.cpu");
+            case "pods":
+                return t("dashboard.charts.queueResources.resourceNames.pods");
+            case "nvidia.com/gpu":
+                return t("dashboard.charts.queueResources.resourceNames.gpu");
+            default:
+                return resource.toUpperCase();
+        }
+    };
+    
     // Build chart data
     const chartData = {
         labels: Object.keys(processedData),
         datasets: [
             {
-                label: `${selectedResource.toUpperCase()} Allocated`,
+                label: t("dashboard.charts.queueResources.allocatedLabel", {
+                    resource: getResourceLabel(selectedResource),
+                }),
                 data: Object.values(processedData).map(
                     (q) => q.allocated[selectedResource] || 0,
                 ),
@@ -101,7 +136,9 @@ const QueueResourcesBarChart = ({ data }) => {
                 borderWidth: 1,
             },
             {
-                label: `${selectedResource.toUpperCase()} Capacity`,
+                label: t("dashboard.charts.queueResources.capacityLabel",{
+                    resource: getResourceLabel(selectedResource)
+                }),
                 data: Object.values(processedData).map(
                     (q) => q.capability[selectedResource] || 0,
                 ),
@@ -116,17 +153,18 @@ const QueueResourcesBarChart = ({ data }) => {
     const getYAxisLabel = () => {
         switch (selectedResource) {
             case "memory":
-                return "Memory (Gi)";
+                return t("dashboard.charts.queueResources.yAxisLabels.memory");
             case "cpu":
-                return "CPU Cores";
+                return t("dashboard.charts.queueResources.yAxisLabels.cpu");
             case "pods":
-                return "Pod Count";
+                return t("dashboard.charts.queueResources.yAxisLabels.pods");
             case "nvidia.com/gpu":
-                return "GPU Count";
+                return t("dashboard.charts.queueResources.yAxisLabels.gpu");
             default:
-                return "Amount";
+                return t("dashboard.charts.queueResources.yAxisLabels.default");
         }
     };
+    
 
     const options = {
         responsive: true,
@@ -175,7 +213,7 @@ const QueueResourcesBarChart = ({ data }) => {
                     mb: 2,
                 }}
             >
-                <Typography variant="h6">Queue Resources</Typography>
+                <Typography variant="h6">{t("dashboard.charts.queueResources.title")}</Typography>
                 <FormControl size="small" sx={{ minWidth: 150 }}>
                     <Select
                         value={selectedResource}
@@ -203,7 +241,7 @@ const QueueResourcesBarChart = ({ data }) => {
                         color="text.secondary"
                         sx={{ mt: 4 }}
                     >
-                        No data available for selected resource type
+                        {t("dashboard.charts.queueResources.noDataForResource")}
                     </Typography>
                 )}
             </Box>

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -4,8 +4,12 @@ import ErrorDisplay from "./ErrorDisplay";
 import DashboardHeader from "./DashboardHeader";
 import StatCardsContainer from "./StatCardsContainer";
 import ChartsContainer from "./ChartsContainer";
+import { useTranslation } from "react-i18next"
 
 const Dashboard = () => {
+
+    const { t }  = useTranslation();
+
     const [dashboardData, setDashboardData] = useState({
         jobs: [],
         queues: [],
@@ -26,11 +30,11 @@ const Dashboard = () => {
             ]);
 
             if (!jobsRes.ok)
-                throw new Error(`Jobs API error: ${jobsRes.status}`);
+                throw new Error(t("dashboard.errors.jobsApi",{status:jobsRes.status}));   
             if (!queuesRes.ok)
-                throw new Error(`Queues API error: ${queuesRes.status}`);
+                throw new Error(t("dashboard.errors.queuesApi",{status:queuesRes.status}));
             if (!podsRes.ok)
-                throw new Error(`Pods API error: ${podsRes.status}`);
+                throw new Error(t("dashboard.errors.podsApi",{status:podsRes.status}));
 
             const [jobsData, queuesData, podsData] = await Promise.all([
                 jobsRes.json(),
@@ -44,7 +48,7 @@ const Dashboard = () => {
                 pods: podsData.items || [],
             });
         } catch (error) {
-            console.error("Error fetching dashboard data:", error);
+            console.error(t("dashboard.errors.fetchDashboardData"), error);
             setError(error.message);
         } finally {
             setRefreshing(false);

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { Box } from "@mui/material";
 import ErrorDisplay from "./ErrorDisplay";
 import DashboardHeader from "./DashboardHeader";
@@ -19,7 +19,7 @@ const Dashboard = () => {
     const [refreshing, setRefreshing] = useState(false);
     const [error, setError] = useState(null);
 
-    const fetchAllData = async () => {
+    const fetchAllData = useCallback(async () => {
         setRefreshing(true);
         setError(null);
         try {
@@ -54,7 +54,7 @@ const Dashboard = () => {
             setRefreshing(false);
             setIsLoading(false);
         }
-    };
+    },[t]);
 
     const handleRefresh = () => {
         fetchAllData();
@@ -62,7 +62,7 @@ const Dashboard = () => {
 
     useEffect(() => {
         fetchAllData();
-    }, []);
+    }, [fetchAllData]);
 
     return (
         <Box

--- a/frontend/src/components/dashboard/DashboardHeader.jsx
+++ b/frontend/src/components/dashboard/DashboardHeader.jsx
@@ -2,8 +2,12 @@ import React from "react";
 import { Box, IconButton, Tooltip } from "@mui/material";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import TitleComponent from "../Titlecomponent";
+import {useTranslation} from "react-i18next";
 
 const DashboardHeader = ({ onRefresh, refreshing }) => {
+
+    const {t} = useTranslation();
+
     return (
         <Box
             sx={{
@@ -13,8 +17,8 @@ const DashboardHeader = ({ onRefresh, refreshing }) => {
                 mb: 3,
             }}
         >
-            <TitleComponent text="Volcano Dashboard" />
-            <Tooltip title="Refresh Data">
+            <TitleComponent text={t("dashboard.title")} />
+            <Tooltip title={t("dashboard.refreshData")}>
                 <IconButton onClick={onRefresh} disabled={refreshing}>
                     <RefreshIcon />
                 </IconButton>

--- a/frontend/src/components/dashboard/StatCardsContainer.jsx
+++ b/frontend/src/components/dashboard/StatCardsContainer.jsx
@@ -2,8 +2,12 @@ import React from "react";
 import { Grid } from "@mui/material";
 import StatCard from "../Charts/StatCard";
 import { calculateSuccessRate } from "./utils";
+import {useTranslation} from "react-i18next"
 
 const StatCardsContainer = ({ jobs, queues, pods }) => {
+
+    const { t } = useTranslation();
+
     const activeQueues =
         queues.filter((q) => q.status?.state === "Open").length || 0;
     const runningPods =
@@ -13,16 +17,16 @@ const StatCardsContainer = ({ jobs, queues, pods }) => {
     return (
         <Grid container spacing={3} sx={{ mb: 3 }}>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Total Jobs" value={jobs?.length || 0} />
+                <StatCard title={t("dashboard.stats.totalJobs")} value={jobs?.length || 0} />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Active Queues" value={activeQueues} />
+                <StatCard title={t("dashboard.stats.activeQueues")} value={activeQueues} />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Running Pods" value={runningPods} />
+                <StatCard title={t("dashboard.stats.runningPods")} value={runningPods} />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Complete Rate" value={`${successRate}%`} />
+                <StatCard title={t("dashboard.stats.completeRate")} value={`${successRate}%`} />
             </Grid>
         </Grid>
     );

--- a/frontend/src/i18n/index.js
+++ b/frontend/src/i18n/index.js
@@ -1,0 +1,27 @@
+import i18n from "i18next";
+import LanguageDetector from "i18next-browser-language-detector";
+import {initReactI18next} from "react-i18next";
+import { translations } from "./translations";
+
+export const defaultLanguage = "en";
+export const supportedLanguage = ["en" | "zn-CN"];
+
+i18n.use(LanguageDetector)
+.use(initReactI18next)
+.init({
+    resources: translations,
+    fallbackLng: defaultLanguage,
+    supportedLng: supportedLanguage,
+    detection :{
+        order:["localstorage", "navigator"],
+        caches: ["localstorage"],
+        convertDetectedLanguage :(language)=> 
+            language?.toLowerCase().startsWith("zh")
+        ? "zh-CN"
+        : language
+
+    },
+    interpolation: {
+        escapeValue: false
+    }
+})

--- a/frontend/src/i18n/index.js
+++ b/frontend/src/i18n/index.js
@@ -1,27 +1,28 @@
 import i18n from "i18next";
-import LanguageDetector from "i18next-browser-language-detector";
-import {initReactI18next} from "react-i18next";
-import { translations } from "./translations";
+import LanguageDetector from "i18next-browser-languagedetector";
+import { initReactI18next } from "react-i18next";
+import { translations } from "./translations.js";
 
 export const defaultLanguage = "en";
-export const supportedLanguage = ["en" | "zn-CN"];
+export const supportedLanguages = ["en", "zh-CN"];
 
 i18n.use(LanguageDetector)
-.use(initReactI18next)
-.init({
-    resources: translations,
-    fallbackLng: defaultLanguage,
-    supportedLng: supportedLanguage,
-    detection :{
-        order:["localstorage", "navigator"],
-        caches: ["localstorage"],
-        convertDetectedLanguage :(language)=> 
-            language?.toLowerCase().startsWith("zh")
-        ? "zh-CN"
-        : language
+    .use(initReactI18next)
+    .init({
+        resources: translations,
+        fallbackLng: defaultLanguage,
+        supportedLngs: supportedLanguages,
+        detection: {
+            order: ["localStorage", "navigator"],
+            caches: ["localStorage"],
+            convertDetectedLanguage: (language) =>
+                language?.toLowerCase().startsWith("zh")
+                    ? "zh-CN"
+                    : language,
+        },
+        interpolation: {
+            escapeValue: false,
+        },
+    });
 
-    },
-    interpolation: {
-        escapeValue: false
-    }
-})
+export default i18n;

--- a/frontend/src/i18n/translations.js
+++ b/frontend/src/i18n/translations.js
@@ -47,6 +47,7 @@ export const translations = {
                     podsApi: "Pods API error: {{status}}",
                     fetchDashboardData: "Error fetching dashboard data",
                 },
+                
             },
         },
     },
@@ -91,6 +92,13 @@ export const translations = {
                         },
                     },
                 },
+                errors: {
+                    jobsApi: "作业 API 错误：{{status}}",
+                    queuesApi: "队列 API 错误：{{status}}",
+                    podsApi: "Pod API 错误：{{status}}",
+                    fetchDashboardData: "获取仪表盘数据时出错",
+                },
+                
             },
         },
     },

--- a/frontend/src/i18n/translations.js
+++ b/frontend/src/i18n/translations.js
@@ -10,9 +10,9 @@ export const translations = {
                     runningPods: "Running Pods",
                     completeRate: "Complete Rate",
                 },
-                charts: {
-                    noDataAvailable: "No data available",
+                charts: {    
                     jobStatus: {
+                        noDataAvailable: "No data available",
                         title: "Jobs Status",
                         status: {
                             completed: "Completed",
@@ -26,6 +26,12 @@ export const translations = {
                             "No data available for selected resource type",
                         allocatedLabel: "{{resource}} Allocated",
                         capacityLabel: "{{resource}} Capacity",
+                        resourceNames: {
+                            memory: "Memory",
+                            cpu: "CPU",
+                            pods: "Pods",
+                            gpu: "GPU",
+                        },
                         resourceLabels: {
                             memory: "Memory Resources",
                             cpu: "CPU Resources",
@@ -63,8 +69,8 @@ export const translations = {
                     completeRate: "完成率",
                 },
                 charts: {
-                    noDataAvailable: "暂无数据",
                     jobStatus: {
+                        noDataAvailable: "暂无数据",
                         title: "作业状态",
                         status: {
                             completed: "已完成",
@@ -75,14 +81,20 @@ export const translations = {
                     queueResources: {
                         title: "队列资源",
                         noDataForResource: "所选资源类型暂无数据",
-                        allocatedLabel: "已分配 {{resource}}",
+                        allocatedLabel: "{{resource}} 已分配",
                         capacityLabel: "{{resource}} 容量",
+                        resourceNames: {
+                            memory: "内存",
+                            cpu: "CPU",
+                            pods: "Pod",
+                            gpu: "GPU",
+                        },
                         resourceLabels: {
                             memory: "内存资源",
                             cpu: "CPU 资源",
                             pods: "Pod 资源",
                             gpu: "GPU 资源",
-                        },
+                        },                   
                         yAxisLabels: {
                             memory: "内存 (Gi)",
                             cpu: "CPU 核数",

--- a/frontend/src/i18n/translations.js
+++ b/frontend/src/i18n/translations.js
@@ -1,0 +1,97 @@
+export const translations = {
+    en: {
+        translation: {
+            dashboard: {
+                title: "Volcano Dashboard",
+                refreshData: "Refresh Data",
+                stats: {
+                    totalJobs: "Total Jobs",
+                    activeQueues: "Active Queues",
+                    runningPods: "Running Pods",
+                    completeRate: "Complete Rate",
+                },
+                charts: {
+                    noDataAvailable: "No data available",
+                    jobStatus: {
+                        title: "Jobs Status",
+                        status: {
+                            completed: "Completed",
+                            running: "Running",
+                            failed: "Failed",
+                        },
+                    },
+                    queueResources: {
+                        title: "Queue Resources",
+                        noDataForResource:
+                            "No data available for selected resource type",
+                        allocatedLabel: "{{resource}} Allocated",
+                        capacityLabel: "{{resource}} Capacity",
+                        resourceLabels: {
+                            memory: "Memory Resources",
+                            cpu: "CPU Resources",
+                            pods: "Pods Resources",
+                            gpu: "GPU Resources",
+                        },
+                        yAxisLabels: {
+                            memory: "Memory (Gi)",
+                            cpu: "CPU Cores",
+                            pods: "Pod Count",
+                            gpu: "GPU Count",
+                            default: "Amount",
+                        },
+                    },
+                },
+                errors: {
+                    jobsApi: "Jobs API error: {{status}}",
+                    queuesApi: "Queues API error: {{status}}",
+                    podsApi: "Pods API error: {{status}}",
+                    fetchDashboardData: "Error fetching dashboard data",
+                },
+            },
+        },
+    },
+    "zh-CN": {
+        translation: {
+            dashboard: {
+                title: "Volcano 仪表盘",
+                refreshData: "刷新数据",
+                stats: {
+                    totalJobs: "作业总数",
+                    activeQueues: "活跃队列",
+                    runningPods: "运行中的 Pod",
+                    completeRate: "完成率",
+                },
+                charts: {
+                    noDataAvailable: "暂无数据",
+                    jobStatus: {
+                        title: "作业状态",
+                        status: {
+                            completed: "已完成",
+                            running: "运行中",
+                            failed: "失败",
+                        },
+                    },
+                    queueResources: {
+                        title: "队列资源",
+                        noDataForResource: "所选资源类型暂无数据",
+                        allocatedLabel: "已分配 {{resource}}",
+                        capacityLabel: "{{resource}} 容量",
+                        resourceLabels: {
+                            memory: "内存资源",
+                            cpu: "CPU 资源",
+                            pods: "Pod 资源",
+                            gpu: "GPU 资源",
+                        },
+                        yAxisLabels: {
+                            memory: "内存 (Gi)",
+                            cpu: "CPU 核数",
+                            pods: "Pod 数量",
+                            gpu: "GPU 数量",
+                            default: "数量",
+                        },
+                    },
+                },
+            },
+        },
+    },
+};

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import "./i18n"
 
 createRoot(document.getElementById("root")).render(
     <StrictMode>

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,8 @@
                 "bootstrap": "^5.3.5",
                 "chart.js": "^4.4.7",
                 "dotenv": "^16.4.7",
+                "i18next": "^26.2.0",
+                "i18next-browser-languagedetector": "^8.2.1",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
                 "lucide-react": "^0.511.0",
@@ -96,6 +98,7 @@
                 "react-bootstrap": "^2.10.9",
                 "react-chartjs-2": "^5.3.0",
                 "react-dom": "^19.0.0",
+                "react-i18next": "^17.0.8",
                 "react-router-dom": "^7.1.5"
             },
             "devDependencies": {
@@ -307,7 +310,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -1966,9 +1968,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -2107,7 +2109,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2131,7 +2132,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2899,6 +2899,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
             "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2980,6 +2981,7 @@
             "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
@@ -3009,7 +3011,8 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
@@ -3306,7 +3309,6 @@
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
             "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.26.0",
                 "@mui/core-downloads-tracker": "^6.5.0",
@@ -3603,7 +3605,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -4090,7 +4091,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -4300,7 +4300,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -4311,7 +4310,6 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -4339,7 +4337,8 @@
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/warning": {
             "version": "3.0.3",
@@ -4506,7 +4505,8 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.7.0",
@@ -4535,7 +4535,6 @@
             "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/user-event": "^14.6.1",
@@ -4722,7 +4721,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5397,7 +5395,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5580,7 +5577,6 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -6270,6 +6266,7 @@
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
             "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
+            "peer": true,
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -6821,6 +6818,7 @@
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -6845,6 +6843,7 @@
             "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -6855,6 +6854,7 @@
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -6868,6 +6868,7 @@
             "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -6885,6 +6886,7 @@
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -6898,6 +6900,7 @@
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -6916,6 +6919,7 @@
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -6929,6 +6933,7 @@
             "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.3",
@@ -6944,6 +6949,7 @@
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -7489,7 +7495,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -7752,7 +7757,8 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -7892,6 +7898,15 @@
                 "node": ">=18"
             }
         },
+        "node_modules/html-parse-stringify": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+            "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+            "license": "MIT",
+            "dependencies": {
+                "void-elements": "3.1.0"
+            }
+        },
         "node_modules/http-errors": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7964,6 +7979,43 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
+            }
+        },
+        "node_modules/i18next": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
+            "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com/i18next"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
+                }
+            ],
+            "license": "MIT",
+            "peerDependencies": {
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/i18next-browser-languagedetector": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+            "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2"
             }
         },
         "node_modules/iconv-lite": {
@@ -8719,7 +8771,6 @@
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 10.16.0"
             }
@@ -9171,6 +9222,7 @@
             "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
             "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -10565,7 +10617,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10616,12 +10667,38 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
                 "react": "^19.2.3"
+            }
+        },
+        "node_modules/react-i18next": {
+            "version": "17.0.8",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+            "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2",
+                "html-parse-stringify": "^3.0.1",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "peerDependencies": {
+                "i18next": ">= 26.2.0",
+                "react": ">= 16.8.0",
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-is": {
@@ -10946,6 +11023,7 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -12181,7 +12259,8 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
@@ -12238,7 +12317,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12422,6 +12500,7 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -12524,7 +12603,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -12675,6 +12754,15 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12705,7 +12793,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -12837,7 +12924,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12851,7 +12937,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -12959,6 +13044,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/void-elements": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+            "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/volcano-dashboard-app": {
@@ -13296,7 +13390,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
             "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },


### PR DESCRIPTION
Part of #243

## Summary

Add i18next-based internationalization support for the Dashboard section and include English and Simplified Chinese translation resources.

## Changes

- Added i18next setup with React integration
- Added browser language detection with localStorage persistence
- Added English and Simplified Chinese Dashboard translation keys
- Replaced Dashboard hardcoded text with i18n keys
- Translated Dashboard stats and errors
- Translated Job Status pie chart title, labels, and empty state
- Translated Queue Resources bar chart title, dropdown labels, axis labels, legend labels, and empty state

## Scope

This PR only covers the Dashboard translations.

Manual verification can be done by setting `i18nextLng` in localStorage to `en` or `zh-CN`. A language switcher will be added in a follow-up PR to make this easier from the UI.


## ScreenShots 
<img width="1916" height="865" alt="image" src="https://github.com/user-attachments/assets/652c01f8-d45f-4a16-8431-737704ea44dc" />


<img width="1916" height="865" alt="image" src="https://github.com/user-attachments/assets/494f6f0b-d1f5-4934-9bde-8542c066fbd0" />





## Verification

- `npm run lint -w frontend`
- `npm run test -w frontend -- --run`
- `npm run build -w frontend`