### PR TITLE
Reduce redundant metadata API requests in dashboard pages

### DIFF
--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -68,9 +68,20 @@ const Jobs = () => {
 
     useEffect(() => {
         fetchJobs();
-        fetchAllNamespaces().then(setAllNamespaces);
-        fetchAllQueues().then(setAllQueues);
     }, [fetchJobs]);
+
+    useEffect(() => {
+        let isMounted = true;
+        fetchAllNamespaces().then((data) => {
+            if (isMounted) setAllNamespaces(data);
+        });
+        fetchAllQueues().then((data) => {
+            if (isMounted) setAllQueues(data);
+        });
+        return () => {
+            isMounted = false;
+        };
+    }, []);
 
     useEffect(() => {
         const startIndex = (pagination.page - 1) * pagination.rowsPerPage;

--- a/frontend/src/components/podgroups/PodGroups.jsx
+++ b/frontend/src/components/podgroups/PodGroups.jsx
@@ -65,8 +65,17 @@ const PodGroups = () => {
 
     useEffect(() => {
         fetchPodGroups();
-        fetchAllNamespaces().then(setAllNamespaces);
     }, [fetchPodGroups]);
+
+    useEffect(() => {
+        let isMounted = true;
+        fetchAllNamespaces().then((data) => {
+            if (isMounted) setAllNamespaces(data);
+        });
+        return () => {
+            isMounted = false;
+        };
+    }, []);
 
     useEffect(() => {
         const startIndex = (pagination.page - 1) * pagination.rowsPerPage;

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -60,8 +60,17 @@ const Pods = () => {
 
     useEffect(() => {
         fetchPods();
-        fetchAllNamespaces().then(setAllNamespaces);
     }, [fetchPods]);
+
+    useEffect(() => {
+        let isMounted = true;
+        fetchAllNamespaces().then((data) => {
+            if (isMounted) setAllNamespaces(data);
+        });
+        return () => {
+            isMounted = false;
+        };
+    }, []);
 
     useEffect(() => {
         const startIndex = (pagination.page - 1) * pagination.rowsPerPage;


### PR DESCRIPTION
## Summary

This PR reduces redundant metadata API requests across the Jobs, Pods, and PodGroups pages.

Previously, metadata fetches such as `fetchAllNamespaces()` and `fetchAllQueues()` were coupled with data-fetch effects that depended on dynamic query callbacks (`fetchJobs`, `fetchPods`, `fetchPodGroups`). Since these callbacks are recreated when search, filters, or pagination state changes, the metadata endpoints were being unnecessarily re-requested multiple times.

## Changes

* Separated metadata fetches into dedicated mount-only `useEffect` hooks
* Preserved existing dynamic data-fetch behavior for jobs, pods, and podgroups
* Reduced unnecessary requests to:

  * `/api/namespaces`
  * `/api/all-queues`

## Files Updated

* `frontend/src/components/jobs/Jobs.jsx`
* `frontend/src/components/pods/Pods.jsx`
* `frontend/src/components/podgroups/PodGroups.jsx`

## Result

* Reduced redundant API requests during search/filter interactions
* Improved frontend request efficiency
* Preserved existing UI behavior and application flow

## Testing

Verified that:

* search and filtering continue to work correctly
* pagination behavior remains unchanged
* metadata requests are no longer repeatedly triggered on query state updates
* no UI regressions were introduced
