### PR TITLE
chore/fix: show refresh loading state in jobs and pod on refresh button

### DIFF
--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -11,7 +11,7 @@ import SearchBar from "../Searchbar";
 const Jobs = () => {
     const [jobs, setJobs] = useState([]);
     const [cachedJobs, setCachedJobs] = useState([]);
-    const [, setLoading] = useState(true);
+    const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [allNamespaces, setAllNamespaces] = useState([]);
     const [allQueues, setAllQueues] = useState([]);
@@ -221,7 +221,7 @@ const Jobs = () => {
                     handleClearSearch={handleClearSearch}
                     handleRefresh={fetchJobs}
                     fetchData={fetchJobs}
-                    isRefreshing={false} // Update if needed
+                    isRefreshing={loading}
                     placeholder="Search jobs..."
                     refreshLabel="Refresh Job Listings"
                     createlabel="Create Job"

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -11,7 +11,7 @@ import PodDetailsDialog from "./PodDetailsDialog";
 const Pods = () => {
     const [pods, setPods] = useState([]);
     const [cachedPods, setCachedPods] = useState([]);
-    const [, setLoading] = useState(true);
+    const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
     const [allNamespaces, setAllNamespaces] = useState([]);
     const [filters, setFilters] = useState({
@@ -193,7 +193,7 @@ const Pods = () => {
                     handleClearSearch={handleClearSearch}
                     handleRefresh={handleRefresh}
                     fetchData={fetchPods}
-                    isRefreshing={false} // Update if needed
+                    isRefreshing={loading}
                     placeholder="Search Pods..."
                     refreshLabel="Refresh Pods"
                     createlabel="Create Pod"


### PR DESCRIPTION
## Summary
The refresh button had `isRefreshing={false}` hardcoded, so the loading spinner and `"Refreshing..."` text never appeared during data fetches.

## Closes #255 

## Changes
- Exposed the `loading` state in:
  - `Jobs.jsx`
  - `Pods.jsx`