### PR TITLE
feat(i18n): add Simplified Chinese translation support to dashboard page

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,27 +13,30 @@ import Pods from "./components/pods/Pods";
 import PodGroups from "./components/podgroups/PodGroups";
 import { ThemeProvider } from "@mui/material/styles";
 import { theme } from "./theme";
+import { I18nProvider } from "./context/I18nContext";
 import "bootstrap/dist/css/bootstrap.min.css";
 
 function App() {
     return (
-        <ThemeProvider theme={theme}>
-            <Router>
-                <Routes>
-                    <Route path="/" element={<Layout />}>
-                        <Route
-                            index
-                            element={<Navigate to="/dashboard" replace />}
-                        />
-                        <Route path="dashboard" element={<Dashboard />} />
-                        <Route path="jobs" element={<Jobs />} />
-                        <Route path="queues" element={<Queues />} />
-                        <Route path="pods" element={<Pods />} />
-                        <Route path="podgroups" element={<PodGroups />} />
-                    </Route>
-                </Routes>
-            </Router>
-        </ThemeProvider>
+        <I18nProvider>
+            <ThemeProvider theme={theme}>
+                <Router>
+                    <Routes>
+                        <Route path="/" element={<Layout />}>
+                            <Route
+                                index
+                                element={<Navigate to="/dashboard" replace />}
+                            />
+                            <Route path="dashboard" element={<Dashboard />} />
+                            <Route path="jobs" element={<Jobs />} />
+                            <Route path="queues" element={<Queues />} />
+                            <Route path="pods" element={<Pods />} />
+                            <Route path="podgroups" element={<PodGroups />} />
+                        </Route>
+                    </Routes>
+                </Router>
+            </ThemeProvider>
+        </I18nProvider>
     );
 }
 

--- a/frontend/src/components/Charts/JobStatusPieChart.jsx
+++ b/frontend/src/components/Charts/JobStatusPieChart.jsx
@@ -2,10 +2,13 @@ import React from "react";
 import { Box, Typography } from "@mui/material";
 import { Doughnut } from "react-chartjs-2";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, Title } from "chart.js";
+import { useI18n } from "../../context/I18nContext";
 
 ChartJS.register(ArcElement, Tooltip, Legend, Title);
 
 const JobStatusPieChart = ({ data }) => {
+    const { t } = useI18n();
+
     if (!data || !Array.isArray(data)) {
         return (
             <Box sx={{ height: 300, width: "100%", position: "relative" }}>
@@ -80,7 +83,7 @@ const JobStatusPieChart = ({ data }) => {
             }}
         >
             <Typography variant="h6" align="center" sx={{ mb: 1 }}>
-                Jobs Status
+                {t("dashboard.statusDistribution", "Jobs Status")}
             </Typography>
 
             <Box
@@ -159,7 +162,7 @@ const JobStatusPieChart = ({ data }) => {
                                 variant="body2"
                                 sx={{ mr: 2, minWidth: 70 }}
                             >
-                                {status}
+                                {t(`common.${status.toLowerCase()}`, status)}
                             </Typography>
                             <Typography variant="body2" color="text.secondary">
                                 {count} (

--- a/frontend/src/components/Charts/PodStatusLineChart.jsx
+++ b/frontend/src/components/Charts/PodStatusLineChart.jsx
@@ -2,15 +2,17 @@ import React from "react";
 import { Box, Typography } from "@mui/material";
 import { Line } from "react-chartjs-2";
 import "./chartConfig";
+import { useI18n } from "../../context/I18nContext";
 
 const PodStatusLineChart = ({ data }) => {
+    const { t } = useI18n();
     const chartData = {
         labels: data.map((pod) =>
             new Date(pod.metadata.creationTimestamp).toLocaleTimeString(),
         ),
         datasets: [
             {
-                label: "Running Pods",
+                label: t("common.runningPods", "Running Pods"),
                 data: data.map((pod) =>
                     pod.status.phase === "Running" ? 1 : 0,
                 ),
@@ -35,7 +37,7 @@ const PodStatusLineChart = ({ data }) => {
     return (
         <Box sx={{ height: 300, width: "100%", position: "relative" }}>
             <Typography variant="h6" gutterBottom>
-                Pod Status Timeline
+                {t("dashboard.podStatusTimeline", "Pod Status Timeline")}
             </Typography>
             <Line data={chartData} options={options} />
         </Box>

--- a/frontend/src/components/Charts/QueueResourcesBarChart.jsx
+++ b/frontend/src/components/Charts/QueueResourcesBarChart.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { Box, FormControl, MenuItem, Select, Typography } from "@mui/material";
 import { Bar } from "react-chartjs-2";
 import "./chartConfig";
+import { useI18n } from "../../context/I18nContext";
 
 const convertMemoryToGi = (memoryStr) => {
     if (!memoryStr) return 0;
@@ -54,6 +55,7 @@ const processData = (data) => {
 };
 
 const QueueResourcesBarChart = ({ data }) => {
+    const { t } = useI18n();
     const [selectedResource, setSelectedResource] = useState("");
 
     // Obtain resource type options dynamically
@@ -71,11 +73,19 @@ const QueueResourcesBarChart = ({ data }) => {
         });
 
         // Convert resource type from Set to Array
-        return Array.from(resourceTypes).map((resource) => ({
-            value: resource,
-            label: `${resource.charAt(0).toUpperCase() + resource.slice(1)} Resources`,
-        }));
-    }, [data]);
+        return Array.from(resourceTypes).map((resource) => {
+            let label = `${resource.charAt(0).toUpperCase() + resource.slice(1)} Resources`;
+            if (resource === "cpu")
+                label = `${t("common.cpu", "CPU")} ${t("common.resources", "Resources")}`;
+            else if (resource === "memory")
+                label = `${t("common.memory", "Memory")} ${t("common.resources", "Resources")}`;
+            else if (resource === "pods")
+                label = `${t("common.pods", "Pods")} ${t("common.resources", "Resources")}`;
+            else if (resource.includes("gpu"))
+                label = `GPU ${t("common.resources", "Resources")}`;
+            return { value: resource, label };
+        });
+    }, [data, t]);
 
     useEffect(() => {
         // If there is a resource option, the first resource is selected by default
@@ -92,7 +102,7 @@ const QueueResourcesBarChart = ({ data }) => {
         labels: Object.keys(processedData),
         datasets: [
             {
-                label: `${selectedResource.toUpperCase()} Allocated`,
+                label: `${selectedResource.toUpperCase()} ${t("common.allocated", "Allocated")}`,
                 data: Object.values(processedData).map(
                     (q) => q.allocated[selectedResource] || 0,
                 ),
@@ -101,7 +111,7 @@ const QueueResourcesBarChart = ({ data }) => {
                 borderWidth: 1,
             },
             {
-                label: `${selectedResource.toUpperCase()} Capacity`,
+                label: `${selectedResource.toUpperCase()} ${t("common.capacity", "Capacity")}`,
                 data: Object.values(processedData).map(
                     (q) => q.capability[selectedResource] || 0,
                 ),
@@ -116,15 +126,15 @@ const QueueResourcesBarChart = ({ data }) => {
     const getYAxisLabel = () => {
         switch (selectedResource) {
             case "memory":
-                return "Memory (Gi)";
+                return `${t("common.memory", "Memory")} (Gi)`;
             case "cpu":
-                return "CPU Cores";
+                return `${t("common.cpu", "CPU")} ${t("common.cores", "Cores")}`;
             case "pods":
-                return "Pod Count";
+                return `${t("common.pods", "Pods")} ${t("common.count", "Count")}`;
             case "nvidia.com/gpu":
-                return "GPU Count";
+                return `GPU ${t("common.count", "Count")}`;
             default:
-                return "Amount";
+                return t("common.amount", "Amount");
         }
     };
 
@@ -175,7 +185,9 @@ const QueueResourcesBarChart = ({ data }) => {
                     mb: 2,
                 }}
             >
-                <Typography variant="h6">Queue Resources</Typography>
+                <Typography variant="h6">
+                    {t("dashboard.resourceAllocation", "Queue Resources")}
+                </Typography>
                 <FormControl size="small" sx={{ minWidth: 150 }}>
                     <Select
                         value={selectedResource}
@@ -203,7 +215,10 @@ const QueueResourcesBarChart = ({ data }) => {
                         color="text.secondary"
                         sx={{ mt: 4 }}
                     >
-                        No data available for selected resource type
+                        {t(
+                            "dashboard.noDataForResource",
+                            "No data available for selected resource type",
+                        )}
                     </Typography>
                 )}
             </Box>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -12,6 +12,9 @@ import {
     Toolbar,
     Typography,
     Tooltip,
+    Menu,
+    MenuItem,
+    Button,
 } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
 import CloudIcon from "@mui/icons-material/Cloud";
@@ -19,6 +22,10 @@ import HomeIcon from "@mui/icons-material/Home";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 import WorkspacesIcon from "@mui/icons-material/Workspaces";
 import CategoryIcon from "@mui/icons-material/Category";
+import TranslateIcon from "@mui/icons-material/Translate";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+
+import { useI18n } from "../context/I18nContext";
 
 // use relative path to load Logo
 import volcanoLogo from "../assets/volcano-icon-color.svg";
@@ -27,6 +34,8 @@ const Layout = () => {
     // Hooks must be used inside component functions
     const location = useLocation();
     const [open, setOpen] = useState(true);
+    const { locale, setLocale, t } = useI18n();
+    const [langAnchorEl, setLangAnchorEl] = useState(null);
 
     // constants can be kept outside the component
     const volcanoOrange = "#E34C26"; // orange red theme
@@ -37,12 +46,48 @@ const Layout = () => {
         setOpen(!open);
     };
 
+    const handleLangClick = (event) => {
+        setLangAnchorEl(event.currentTarget);
+    };
+
+    const handleLangClose = (newLocale) => {
+        setLangAnchorEl(null);
+        if (newLocale === "en" || newLocale === "zh") {
+            setLocale(newLocale);
+        }
+    };
+
     const menuItems = [
-        { text: "Dashboard", icon: <HomeIcon />, path: "/dashboard" },
-        { text: "Jobs", icon: <AssignmentIcon />, path: "/jobs" },
-        { text: "Queues", icon: <CloudIcon />, path: "/queues" },
-        { text: "Pods", icon: <WorkspacesIcon />, path: "/pods" },
-        { text: "PodGroups", icon: <CategoryIcon />, path: "/podgroups" },
+        {
+            text: t("sidebar.dashboard"),
+            icon: <HomeIcon />,
+            path: "/dashboard",
+            key: "dashboard",
+        },
+        {
+            text: t("sidebar.jobs"),
+            icon: <AssignmentIcon />,
+            path: "/jobs",
+            key: "jobs",
+        },
+        {
+            text: t("sidebar.queues"),
+            icon: <CloudIcon />,
+            path: "/queues",
+            key: "queues",
+        },
+        {
+            text: t("sidebar.pods"),
+            icon: <WorkspacesIcon />,
+            path: "/pods",
+            key: "pods",
+        },
+        {
+            text: t("sidebar.podgroups"),
+            icon: <CategoryIcon />,
+            path: "/podgroups",
+            key: "podgroups",
+        },
     ];
 
     return (
@@ -71,10 +116,81 @@ const Layout = () => {
                         sx={{
                             color: "#ffffff",
                             fontWeight: 500,
+                            flexGrow: 1,
                         }}
                     >
-                        Volcano Dashboard
+                        {t("dashboard.title")}
                     </Typography>
+
+                    {/* Language Dropdown Selector */}
+                    <Box sx={{ ml: "auto" }}>
+                        <Button
+                            color="inherit"
+                            onClick={handleLangClick}
+                            startIcon={<TranslateIcon />}
+                            endIcon={<KeyboardArrowDownIcon />}
+                            sx={{
+                                color: "#ffffff",
+                                textTransform: "none",
+                                borderRadius: "20px",
+                                px: 2,
+                                py: 0.5,
+                                fontSize: "0.9rem",
+                                fontWeight: 500,
+                                backgroundColor: "rgba(255, 255, 255, 0.08)",
+                                "&:hover": {
+                                    backgroundColor:
+                                        "rgba(255, 255, 255, 0.15)",
+                                },
+                            }}
+                        >
+                            {locale === "en" ? "English" : "简体中文"}
+                        </Button>
+                        <Menu
+                            anchorEl={langAnchorEl}
+                            open={Boolean(langAnchorEl)}
+                            onClose={() => handleLangClose()}
+                            PaperProps={{
+                                sx: {
+                                    mt: 1,
+                                    borderRadius: "12px",
+                                    boxShadow: "0px 10px 25px rgba(0,0,0,0.1)",
+                                    border: "1px solid rgba(0,0,0,0.06)",
+                                    "& .MuiMenuItem-root": {
+                                        fontSize: "0.9rem",
+                                        py: 1,
+                                        px: 2,
+                                        borderRadius: "6px",
+                                        mx: 0.5,
+                                        my: 0.2,
+                                        fontWeight: 500,
+                                        "&.Mui-selected": {
+                                            backgroundColor:
+                                                "rgba(227, 76, 38, 0.08)",
+                                            color: "#E34C26",
+                                            "&:hover": {
+                                                backgroundColor:
+                                                    "rgba(227, 76, 38, 0.12)",
+                                            },
+                                        },
+                                    },
+                                },
+                            }}
+                        >
+                            <MenuItem
+                                selected={locale === "en"}
+                                onClick={() => handleLangClose("en")}
+                            >
+                                English
+                            </MenuItem>
+                            <MenuItem
+                                selected={locale === "zh"}
+                                onClick={() => handleLangClose("zh")}
+                            >
+                                简体中文
+                            </MenuItem>
+                        </Menu>
+                    </Box>
                 </Toolbar>
             </AppBar>
 
@@ -101,7 +217,7 @@ const Layout = () => {
                         {menuItems.map((item) => {
                             const listItem = (
                                 <ListItem
-                                    key={item.text}
+                                    key={item.key}
                                     component={Link}
                                     to={item.path}
                                     className={
@@ -134,14 +250,14 @@ const Layout = () => {
                             );
                             return !open ? (
                                 <Tooltip
-                                    key={item.text}
+                                    key={item.key}
                                     title={item.text}
                                     placement="right"
                                 >
                                     {listItem}
                                 </Tooltip>
                             ) : (
-                                <React.Fragment key={item.text}>
+                                <React.Fragment key={item.key}>
                                     {listItem}
                                 </React.Fragment>
                             );
@@ -158,7 +274,6 @@ const Layout = () => {
                         alignItems: "center",
                         mt: "auto",
                         mb: 1,
-                        // borderTop: "1px solid rgba(0, 0, 0, 0.12)",
                     }}
                 >
                     <img
@@ -171,19 +286,6 @@ const Layout = () => {
                             marginBottom: "1px",
                         }}
                     />
-                    {/* {open && (
-            <Typography
-              sx={{
-                fontWeight: 700,
-                color: "#000",
-                fontSize: "1.4rem",
-                letterSpacing: "0.1em",
-                mt: -6,
-              }}
-            >
-              VOLCANO
-            </Typography>
-          )} */}
                 </Box>
             </Drawer>
             <Box

--- a/frontend/src/components/dashboard/DashboardHeader.jsx
+++ b/frontend/src/components/dashboard/DashboardHeader.jsx
@@ -2,8 +2,10 @@ import React from "react";
 import { Box, IconButton, Tooltip } from "@mui/material";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import TitleComponent from "../Titlecomponent";
+import { useI18n } from "../../context/I18nContext";
 
 const DashboardHeader = ({ onRefresh, refreshing }) => {
+    const { t } = useI18n();
     return (
         <Box
             sx={{
@@ -13,8 +15,8 @@ const DashboardHeader = ({ onRefresh, refreshing }) => {
                 mb: 3,
             }}
         >
-            <TitleComponent text="Volcano Dashboard" />
-            <Tooltip title="Refresh Data">
+            <TitleComponent text={t("dashboard.title")} />
+            <Tooltip title={t("common.refresh")}>
                 <IconButton onClick={onRefresh} disabled={refreshing}>
                     <RefreshIcon />
                 </IconButton>

--- a/frontend/src/components/dashboard/StatCardsContainer.jsx
+++ b/frontend/src/components/dashboard/StatCardsContainer.jsx
@@ -2,8 +2,10 @@ import React from "react";
 import { Grid } from "@mui/material";
 import StatCard from "../Charts/StatCard";
 import { calculateSuccessRate } from "./utils";
+import { useI18n } from "../../context/I18nContext";
 
 const StatCardsContainer = ({ jobs, queues, pods }) => {
+    const { t } = useI18n();
     const activeQueues =
         queues.filter((q) => q.status?.state === "Open").length || 0;
     const runningPods =
@@ -13,16 +15,28 @@ const StatCardsContainer = ({ jobs, queues, pods }) => {
     return (
         <Grid container spacing={3} sx={{ mb: 3 }}>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Total Jobs" value={jobs?.length || 0} />
+                <StatCard
+                    title={t("dashboard.totalJobs")}
+                    value={jobs?.length || 0}
+                />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Active Queues" value={activeQueues} />
+                <StatCard
+                    title={t("dashboard.activeQueues", "Active Queues")}
+                    value={activeQueues}
+                />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Running Pods" value={runningPods} />
+                <StatCard
+                    title={t("dashboard.runningPods", "Running Pods")}
+                    value={runningPods}
+                />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Complete Rate" value={`${successRate}%`} />
+                <StatCard
+                    title={t("dashboard.completeRate", "Complete Rate")}
+                    value={`${successRate}%`}
+                />
             </Grid>
         </Grid>
     );

--- a/frontend/src/components/jobs/JobTable/JobTable.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTable.jsx
@@ -12,6 +12,7 @@ import {
 import JobTableHeader from "./JobTableHeader";
 import JobTableRow from "./JobTableRow";
 import JobTableDeleteDialog from "./JobTableDeleteDialog"; // Be sure to have this component
+import { useI18n } from "../../../context/I18nContext";
 
 const JobTable = ({
     jobs,
@@ -29,6 +30,7 @@ const JobTable = ({
     reloadJobs, // (optional) for refetching after delete
 }) => {
     const theme = useTheme();
+    const { t } = useI18n();
 
     // State for delete dialog
     const [openDeleteDialog, setOpenDeleteDialog] = useState(false);
@@ -160,7 +162,7 @@ const JobTable = ({
                         {jobs.length === 0 ? (
                             <TableRow>
                                 <TableCell colSpan={8} align="center">
-                                    No jobs found.
+                                    {t("jobs.noJobs")}
                                 </TableCell>
                             </TableRow>
                         ) : (

--- a/frontend/src/components/jobs/JobTable/JobTableHeader.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTableHeader.jsx
@@ -11,6 +11,7 @@ import {
 } from "@mui/material";
 import { ArrowDownward, ArrowUpward, UnfoldMore } from "@mui/icons-material";
 import JobFilters from "./JobFilters";
+import { useI18n } from "../../../context/I18nContext";
 
 const JobTableHeader = ({
     filters,
@@ -24,6 +25,7 @@ const JobTableHeader = ({
     toggleSortDirection,
 }) => {
     const theme = useTheme();
+    const { t } = useI18n();
 
     return (
         <TableHead>
@@ -45,13 +47,16 @@ const JobTableHeader = ({
                         fontWeight="700"
                         color="text.primary"
                     >
-                        Name
+                        {t("common.name")}
                     </Typography>
                 </TableCell>
 
-                {["Namespace", "Queue"].map((field) => (
+                {[
+                    { key: "namespace", label: t("common.namespace") },
+                    { key: "queue", label: t("common.queue") },
+                ].map((field) => (
                     <TableCell
-                        key={field}
+                        key={field.key}
                         sx={{
                             backgroundColor: alpha(
                                 theme.palette.background.paper,
@@ -74,19 +79,19 @@ const JobTableHeader = ({
                                 fontWeight="700"
                                 color="text.primary"
                             >
-                                {field}
+                                {field.label}
                             </Typography>
                             <JobFilters
-                                filterType={field.toLowerCase()}
-                                currentValue={filters[field.toLowerCase()]}
+                                filterType={field.key}
+                                currentValue={filters[field.key]}
                                 options={
-                                    field === "Namespace"
+                                    field.key === "namespace"
                                         ? allNamespaces
                                         : allQueues
                                 }
                                 handleFilterClick={handleFilterClick}
                                 handleFilterClose={handleFilterClose}
-                                anchorEl={anchorEl[field.toLowerCase()]}
+                                anchorEl={anchorEl[field.key]}
                             />
                         </Box>
                     </TableCell>
@@ -109,7 +114,7 @@ const JobTableHeader = ({
                         fontWeight="700"
                         color="text.primary"
                     >
-                        Creation Time
+                        {t("common.creationTime")}
                     </Typography>
                     <Button
                         size="small"
@@ -146,7 +151,7 @@ const JobTableHeader = ({
                             },
                         }}
                     >
-                        Sort
+                        {t("common.sort", "Sort")}
                     </Button>
                 </TableCell>
 
@@ -167,7 +172,7 @@ const JobTableHeader = ({
                         fontWeight="700"
                         color="text.primary"
                     >
-                        Status
+                        {t("common.status")}
                     </Typography>
                     <JobFilters
                         filterType="status"
@@ -179,7 +184,6 @@ const JobTableHeader = ({
                     />
                 </TableCell>
 
-                {/* New Actions Column */}
                 <TableCell
                     sx={{
                         backgroundColor: alpha(
@@ -198,7 +202,7 @@ const JobTableHeader = ({
                         color="text.primary"
                         sx={{ letterSpacing: "0.02em" }}
                     >
-                        Actions
+                        {t("common.actions")}
                     </Typography>
                 </TableCell>
             </TableRow>

--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -7,8 +7,10 @@ import JobTable from "./JobTable/JobTable";
 import JobPagination from "./JobPagination";
 import JobDialog from "./JobDialog";
 import SearchBar from "../Searchbar";
+import { useI18n } from "../../context/I18nContext";
 
 const Jobs = () => {
+    const { t } = useI18n();
     const [jobs, setJobs] = useState([]);
     const [cachedJobs, setCachedJobs] = useState([]);
     const [, setLoading] = useState(true);
@@ -157,13 +159,13 @@ const Jobs = () => {
                 } catch {
                     // ignore error
                 }
-                alert("Error creating job: " + errorMsg);
+                alert(t("jobs.createError", "Error creating job: ") + errorMsg);
                 return;
             }
 
-            alert("Job created successfully!");
+            alert(t("jobs.createSuccess", "Job created successfully!"));
         } catch (err) {
-            alert("Network error: " + err.message);
+            alert(t("jobs.networkError", "Network error: ") + err.message);
         }
     };
 
@@ -213,7 +215,7 @@ const Jobs = () => {
                     <Typography variant="body1">{error}</Typography>
                 </Box>
             )}
-            <TitleComponent text="Volcano Jobs Status" />
+            <TitleComponent text={t("jobs.title")} />
             <Box>
                 <SearchBar
                     searchText={searchText}
@@ -222,12 +224,12 @@ const Jobs = () => {
                     handleRefresh={fetchJobs}
                     fetchData={fetchJobs}
                     isRefreshing={false} // Update if needed
-                    placeholder="Search jobs..."
-                    refreshLabel="Refresh Job Listings"
-                    createlabel="Create Job"
-                    dialogTitle="Create a Job"
-                    dialogResourceNameLabel="Job Name"
-                    dialogResourceType="Job"
+                    placeholder={t("jobs.searchPlaceholder")}
+                    refreshLabel={t("jobs.refreshLabel")}
+                    createlabel={t("jobs.createLabel")}
+                    dialogTitle={t("jobs.dialogTitle")}
+                    dialogResourceNameLabel={t("jobs.dialogResourceNameLabel")}
+                    dialogResourceType={t("jobs.dialogResourceType")}
                     onCreateClick={handleCreateJob}
                 />
             </Box>

--- a/frontend/src/context/I18nContext.jsx
+++ b/frontend/src/context/I18nContext.jsx
@@ -1,0 +1,266 @@
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+// Translation dictionary for English and Simplified Chinese.
+const translations = {
+    en: {
+        common: {
+            dashboard: "Dashboard",
+            jobs: "Jobs",
+            queues: "Queues",
+            queue: "Queue",
+            pods: "Pods",
+            podgroups: "PodGroups",
+            refresh: "Refresh Data",
+            actions: "Actions",
+            status: "Status",
+            name: "Name",
+            namespace: "Namespace",
+            creationTime: "Creation Time",
+            search: "Search...",
+            all: "All",
+            cancel: "Cancel",
+            submit: "Submit",
+            delete: "Delete",
+            noData: "No data found",
+            close: "Close",
+            confirm: "Confirm",
+            activeQueues: "Active Queues",
+            runningPods: "Running Pods",
+            completeRate: "Complete Rate",
+            sort: "Sort",
+        },
+        sidebar: {
+            dashboard: "Dashboard",
+            jobs: "Jobs",
+            queues: "Queues",
+            pods: "Pods",
+            podgroups: "PodGroups",
+        },
+        dashboard: {
+            title: "Volcano Dashboard",
+            totalJobs: "Total Jobs",
+            totalQueues: "Total Queues",
+            totalPods: "Total Pods",
+            pendingJobs: "Pending Jobs",
+            runningJobs: "Running Jobs",
+            completedJobs: "Completed Jobs",
+            failedJobs: "Failed Jobs",
+            jobDistribution: "Job Distribution by Queue",
+            resourceAllocation: "Queue Resource Allocation",
+            weightAllocation: "Queue Weight Allocation",
+            statusDistribution: "Job Status Distribution",
+            refreshSuccess: "Data refreshed successfully",
+            activeQueues: "Active Queues",
+            runningPods: "Running Pods",
+            completeRate: "Complete Rate",
+        },
+        jobs: {
+            title: "Volcano Jobs Status",
+            searchPlaceholder: "Search jobs...",
+            refreshLabel: "Refresh Job Listings",
+            createLabel: "Create Job",
+            dialogTitle: "Create a Job",
+            dialogResourceNameLabel: "Job Name",
+            dialogResourceType: "Job",
+            noJobs: "No jobs found.",
+            rowsPerPage: "Rows per page",
+            yamlDetails: "YAML Details",
+        },
+        queues: {
+            title: "Volcano Queues Status",
+            searchPlaceholder: "Search queues...",
+            refreshLabel: "Refresh Queue Listings",
+            createLabel: "Create Queue",
+            dialogTitle: "Create a Queue",
+            dialogResourceNameLabel: "Queue Name",
+            dialogResourceType: "Queue",
+            noQueues: "No queues found.",
+            weight: "Weight",
+            reclaimable: "Reclaimable",
+        },
+        pods: {
+            title: "Volcano Pods Status",
+            searchPlaceholder: "Search pods...",
+            refreshLabel: "Refresh Pod Listings",
+            createLabel: "Create Pod",
+            dialogTitle: "Create a Pod",
+            dialogResourceNameLabel: "Pod Name",
+            dialogResourceType: "Pod",
+            noPods: "No pods found.",
+            node: "Node",
+            ip: "IP",
+        },
+        podgroups: {
+            title: "Volcano PodGroups Status",
+            searchPlaceholder: "Search podgroups...",
+            refreshLabel: "Refresh PodGroup Listings",
+            noPodGroups: "No podgroups found.",
+            minAvailable: "Min Available",
+        },
+    },
+    zh: {
+        common: {
+            dashboard: "仪表盘",
+            jobs: "任务",
+            queues: "队列",
+            queue: "队列",
+            pods: "容器组 (Pods)",
+            podgroups: "容器组组 (PodGroups)",
+            refresh: "刷新数据",
+            actions: "操作",
+            status: "状态",
+            name: "名称",
+            namespace: "命名空间",
+            creationTime: "创建时间",
+            search: "搜索...",
+            all: "全部",
+            cancel: "取消",
+            submit: "提交",
+            delete: "删除",
+            noData: "暂无数据",
+            close: "关闭",
+            confirm: "确认",
+            activeQueues: "活动队列",
+            runningPods: "运行中 Pods",
+            completeRate: "完成率",
+            sort: "排序",
+        },
+        sidebar: {
+            dashboard: "控制台",
+            jobs: "任务管理",
+            queues: "队列管理",
+            pods: "Pods 容器组",
+            podgroups: "PodGroups 容器组组",
+        },
+        dashboard: {
+            title: "Volcano 仪表盘",
+            totalJobs: "任务总数",
+            totalQueues: "队列总数",
+            totalPods: "Pods 总数",
+            pendingJobs: "待处理任务",
+            runningJobs: "运行中任务",
+            completedJobs: "已完成任务",
+            failedJobs: "失败任务",
+            jobDistribution: "队列任务分布",
+            resourceAllocation: "队列资源分配",
+            weightAllocation: "队列权重分配",
+            statusDistribution: "任务状态分布",
+            refreshSuccess: "数据刷新成功",
+            activeQueues: "活动队列",
+            runningPods: "运行中 Pods",
+            completeRate: "完成率",
+        },
+        jobs: {
+            title: "Volcano 任务状态",
+            searchPlaceholder: "搜索任务...",
+            refreshLabel: "刷新任务列表",
+            createLabel: "创建任务",
+            dialogTitle: "新建任务",
+            dialogResourceNameLabel: "任务名称",
+            dialogResourceType: "任务",
+            noJobs: "未找到任务。",
+            rowsPerPage: "每页行数",
+            yamlDetails: "YAML 详情",
+        },
+        queues: {
+            title: "Volcano 队列状态",
+            searchPlaceholder: "搜索队列...",
+            refreshLabel: "刷新队列列表",
+            createLabel: "创建队列",
+            dialogTitle: "新建队列",
+            dialogResourceNameLabel: "队列名称",
+            dialogResourceType: "队列",
+            noQueues: "未找到队列。",
+            weight: "权重",
+            reclaimable: "可回收",
+        },
+        pods: {
+            title: "Volcano Pods 状态",
+            searchPlaceholder: "搜索 Pods...",
+            refreshLabel: "刷新 Pod 列表",
+            createLabel: "创建 Pod",
+            dialogTitle: "新建 Pod",
+            dialogResourceNameLabel: "Pod 名称",
+            dialogResourceType: "Pod",
+            noPods: "未找到 Pods。",
+            node: "所在节点",
+            ip: "IP 地址",
+        },
+        podgroups: {
+            title: "Volcano PodGroups 状态",
+            searchPlaceholder: "搜索 PodGroups...",
+            refreshLabel: "刷新 PodGroup 列表",
+            noPodGroups: "未找到 PodGroups。",
+            minAvailable: "最小可用数",
+        },
+    },
+};
+
+const I18nContext = createContext(null);
+
+export const I18nProvider = ({ children }) => {
+    // Read initial locale from localStorage or default to English.
+    const [locale, setLocaleState] = useState(() => {
+        const saved = localStorage.getItem("volcano_locale");
+        return saved === "zh" || saved === "en" ? saved : "en";
+    });
+
+    const setLocale = (newLocale) => {
+        if (newLocale === "en" || newLocale === "zh") {
+            setLocaleState(newLocale);
+            localStorage.setItem("volcano_locale", newLocale);
+        }
+    };
+
+    const toggleLocale = () => {
+        setLocale(locale === "en" ? "zh" : "en");
+    };
+
+    /**
+     * Translate function supporting nested path keys (e.g. 'dashboard.title')
+     */
+    const t = (path, defaultValue = "") => {
+        if (!path) return "";
+
+        const keys = path.split(".");
+        let result = translations[locale];
+
+        for (const key of keys) {
+            if (result && typeof result === "object" && key in result) {
+                result = result[key];
+            } else {
+                // Key not found, fall back to English dictionary.
+                let fallback = translations["en"];
+                for (const fallbackKey of keys) {
+                    if (
+                        fallback &&
+                        typeof fallback === "object" &&
+                        fallbackKey in fallback
+                    ) {
+                        fallback = fallback[fallbackKey];
+                    } else {
+                        fallback = null;
+                        break;
+                    }
+                }
+                return fallback !== null ? fallback : defaultValue || path;
+            }
+        }
+
+        return typeof result === "string" ? result : defaultValue || path;
+    };
+
+    return (
+        <I18nContext.Provider value={{ locale, setLocale, toggleLocale, t }}>
+            {children}
+        </I18nContext.Provider>
+    );
+};
+
+export const useI18n = () => {
+    const context = useContext(I18nContext);
+    if (!context) {
+        throw new Error("useI18n must be used within an I18nProvider");
+    }
+    return context;
+};

--- a/frontend/src/context/I18nContext.jsx
+++ b/frontend/src/context/I18nContext.jsx
@@ -28,6 +28,18 @@ const translations = {
             runningPods: "Running Pods",
             completeRate: "Complete Rate",
             sort: "Sort",
+            cpu: "CPU",
+            memory: "Memory",
+            resources: "Resources",
+            allocated: "Allocated",
+            capacity: "Capacity",
+            completed: "Completed",
+            running: "Running",
+            failed: "Failed",
+            pending: "Pending",
+            cores: "Cores",
+            count: "Count",
+            amount: "Amount",
         },
         sidebar: {
             dashboard: "Dashboard",
@@ -53,6 +65,8 @@ const translations = {
             activeQueues: "Active Queues",
             runningPods: "Running Pods",
             completeRate: "Complete Rate",
+            podStatusTimeline: "Pod Status Timeline",
+            noDataForResource: "No data available for selected resource type",
         },
         jobs: {
             title: "Volcano Jobs Status",
@@ -124,6 +138,18 @@ const translations = {
             runningPods: "运行中 Pods",
             completeRate: "完成率",
             sort: "排序",
+            cpu: "CPU",
+            memory: "内存",
+            resources: "资源",
+            allocated: "已分配",
+            capacity: "容量",
+            completed: "已完成",
+            running: "运行中",
+            failed: "已失败",
+            pending: "等待中",
+            cores: "核数",
+            count: "数量",
+            amount: "数量",
         },
         sidebar: {
             dashboard: "控制台",
@@ -149,6 +175,8 @@ const translations = {
             activeQueues: "活动队列",
             runningPods: "运行中 Pods",
             completeRate: "完成率",
+            podStatusTimeline: "Pod 状态时间线",
+            noDataForResource: "所选资源类型无可用数据",
         },
         jobs: {
             title: "Volcano 任务状态",
@@ -229,6 +257,8 @@ export const I18nProvider = ({ children }) => {
             if (result && typeof result === "object" && key in result) {
                 result = result[key];
             } else {
+                if (locale === "en") return defaultValue || path;
+
                 // Key not found, fall back to English dictionary.
                 let fallback = translations["en"];
                 for (const fallbackKey of keys) {

--- a/frontend/tests/Layout.test.jsx
+++ b/frontend/tests/Layout.test.jsx
@@ -1,6 +1,7 @@
 import Layout from "../src/components/Layout";
 import { MemoryRouter } from "react-router-dom";
 import { fireEvent, render, screen } from "@testing-library/react";
+import { I18nProvider } from "../src/context/I18nContext";
 
 const menuItems = [
     { text: "Dashboard", path: "/dashboard" },
@@ -13,9 +14,11 @@ const menuItems = [
 describe("Layout", () => {
     it("should render the layout", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nProvider>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nProvider>,
         );
 
         const heading = screen.getByText(/volcano dashboard/i);
@@ -24,9 +27,11 @@ describe("Layout", () => {
 
     it("should toggle the drawer when clicking the menu button", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nProvider>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nProvider>,
         );
 
         const menuButton = screen.getByRole("button", {
@@ -46,9 +51,11 @@ describe("Layout", () => {
 
     it("should have 5 navigation items", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nProvider>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nProvider>,
         );
 
         const navigationItems = screen.getAllByRole("link");
@@ -65,9 +72,11 @@ describe("Layout", () => {
 
     it("should render logo", () => {
         render(
-            <MemoryRouter>
-                <Layout />
-            </MemoryRouter>,
+            <I18nProvider>
+                <MemoryRouter>
+                    <Layout />
+                </MemoryRouter>
+            </I18nProvider>,
         );
 
         const logo = screen.getByAltText(/volcano logo/i);


### PR DESCRIPTION
## Overview
This PR completes the prerequisite contribution task for LFX applicants by adding Simplified Chinese translation support to the Volcano Dashboard. 

Instead of hardcoding Chinese strings directly into the components, I set up a custom React Context (`I18nContext.jsx`). This handles translation state, language switching, and saves the user's choice across reloads without needing any extra heavy libraries.

## What was changed

1. **Custom React I18n Context (`I18nContext.jsx`)**
   * Added an `I18nProvider` context wrapper and a `useI18n` hook that works well with React 19.
   * Supports nested translation keys (like `t('dashboard.title')`) to keep the dictionary structured.
   * Added fallback logic: if a translation key is missing in Chinese, it automatically uses the English text.
   * Saves the chosen language (`en`/`zh`) to `localStorage` so the setting persists when you refresh the page.

2. **Language Dropdown Selector (`Layout.jsx`)**
   * Added a language selector dropdown inside the top navigation bar using standard Material-UI components.
   * Placed the selector on the right side of the toolbar.

3. **Page and Component Translations**
   * Mapped sidebar navigation labels and dashboard status cards (Total Jobs, Active Queues, Running Pods, and Complete Rate).
   * Mapped the main Volcano Jobs list page (including column headers, action buttons, filter inputs, and search place holders).
   * Fully automated chart text and labels translation (`JobStatusPieChart.jsx`, `QueueResourcesBarChart.jsx`, and `PodStatusLineChart.jsx`). Chart titles, legends (Completed, Running, Failed), dropdown items (e.g. CPU, Memory, Pods), empty state messages, and axes titles translate dynamically when switching language.

4. **Mock Backend Fallback Support (`server.js`)**
   * Updated the local Node development backend so that if the underlying cluster lacks active batch jobs or allocated queue capacities, the endpoints populate full-featured mock Volcano jobs and queue specifications. This ensures developers can immediately view and interact with vibrant, responsive pie/bar charts representing real-world usage.

5. **Test Suite Adaptation (`Layout.test.jsx`)**
   * Wrapped the unit tests inside the `I18nProvider` context wrapper, resolving rendering context issues and ensuring 100% of the React unit tests pass cleanly.

## Visual Verification

Here are screenshots showing the translated interface in action.

### English View
<img width="1456" height="867" alt="Screenshot 2026-05-17 at 12 45 24 PM" src="https://github.com/user-attachments/assets/6e204c9d-7729-4b88-8f37-05deea1aec8f" />


### Simplified Chinese View
<img width="1458" height="869" alt="Screenshot 2026-05-17 at 12 45 39 PM" src="https://github.com/user-attachments/assets/1ba9d909-4d8e-4b88-ae9b-85bfbe0696a4" />


## Verification and Testing
I tested these changes locally to make sure everything works:
* **Saved Preferences**: Verified that switching to Chinese and reloading keeps Chinese selected.
* **Instant Updates**: Confirmed all text updates immediately when switching languages without needing a page refresh.
* **Fallback Behavior**: Tested that missing keys display their English versions without crashing the app.
* **Chart Localization**: Switched languages and confirmed that all chart axes, legends, dropdown options, and card titles translate immediately.
* **Unit Tests**: Executed `npm run test` successfully with 100% of tests passing.
