### PR TITLE
fix: add alert when clicked on create pods and podsgroup

### DIFF
--- a/frontend/src/components/Searchbar.jsx
+++ b/frontend/src/components/Searchbar.jsx
@@ -29,17 +29,24 @@ const SearchBar = ({
     refreshLabel,
     onCreateClick,
     createlabel,
+    onCreateDialogUnavailable,
 }) => {
     const [dialogOpen, setDialogOpen] = useState(false);
 
-    const handleOpenDialog = () => setDialogOpen(true);
+    const handleOpenDialog = () => {
+        if(onCreateDialogUnavailable) {
+            onCreateDialogUnavailable();
+            return ;
+        }
+        setDialogOpen(true);
+    };
     const handleCloseDialog = () => setDialogOpen(false);
 
     const handleDialogCreate = async (resourceData) => {
         if (onCreateClick) {
             await onCreateClick(resourceData);
         }
-        setDialogOpen(false);
+        setDialogOpen(false);              
     };
 
     return (

--- a/frontend/src/components/podgroups/PodGroups.jsx
+++ b/frontend/src/components/podgroups/PodGroups.jsx
@@ -192,7 +192,7 @@ const PodGroups = () => {
                     dialogTitle="Create PodGroup"
                     dialogResourceNameLabel="Name"
                     dialogResourceType="PodGroup"
-                    onCreateClick={handleCreate}
+                    onCreateDialogUnavailable={handleCreate}
                 />
             </Box>
             <PodGroupsTable

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -177,6 +177,11 @@ const Pods = () => {
     const toggleSortDirection = useCallback(() => {
         setSortDirection((prev) => (prev === "asc" ? "desc" : "asc"));
     }, []);
+    
+    // For now, no creation dialog
+    const handleCreate = () => {
+        alert("Create Pod is not supported yet");
+    };
 
     return (
         <Box sx={{ bgcolor: "background.default", minHeight: "100vh", p: 3 }}>
@@ -200,7 +205,7 @@ const Pods = () => {
                     dialogTitle="Create a Pod"
                     dialogResourceNameLabel="Pod Name"
                     dialogResourceType="Pod"
-                    onCreateClick={handleCreatePod}
+                    onCreateDialogUnavailable={handleCreate}
                 />
             </Box>
             <PodsTable


### PR DESCRIPTION
## Description

#260 

Added fallback feedback for create actions that do not currently have a supported dialog.

## Changes

- Added an optional `onCreateDialogUnavailable` handler to the shared `SearchBar`
- Updated Pods and PodGroups pages to show a clear message when create is unavailable
- Kept existing Job and Queue create dialog behavior unchanged

## jScreenShots 

<img width="1910" height="1042" alt="image" src="https://github.com/user-attachments/assets/24de2b03-a05b-43cb-a2f3-03736fefb1be" />

<img width="1910" height="1042" alt="image" src="https://github.com/user-attachments/assets/a7ae83ca-061d-4e5e-88fb-4132d65f67c8" />
