### PR TITLE
fix: replace broken API config with centralized axios instance

### DIFF
--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -4,6 +4,7 @@ import ErrorDisplay from "./ErrorDisplay";
 import DashboardHeader from "./DashboardHeader";
 import StatCardsContainer from "./StatCardsContainer";
 import ChartsContainer from "./ChartsContainer";
+import apiClient from "../../config/api";
 
 const Dashboard = () => {
     const [dashboardData, setDashboardData] = useState({
@@ -20,28 +21,15 @@ const Dashboard = () => {
         setError(null);
         try {
             const [jobsRes, queuesRes, podsRes] = await Promise.all([
-                fetch("/api/jobs?limit=1000"),
-                fetch("/api/queues?limit=1000"),
-                fetch("/api/pods?limit=1000"),
-            ]);
-
-            if (!jobsRes.ok)
-                throw new Error(`Jobs API error: ${jobsRes.status}`);
-            if (!queuesRes.ok)
-                throw new Error(`Queues API error: ${queuesRes.status}`);
-            if (!podsRes.ok)
-                throw new Error(`Pods API error: ${podsRes.status}`);
-
-            const [jobsData, queuesData, podsData] = await Promise.all([
-                jobsRes.json(),
-                queuesRes.json(),
-                podsRes.json(),
+                apiClient.get("/jobs?limit=1000"),
+                apiClient.get("/queues?limit=1000"),
+                apiClient.get("/pods?limit=1000"),
             ]);
 
             setDashboardData({
-                jobs: jobsData.items || [],
-                queues: queuesData.items || [],
-                pods: podsData.items || [],
+                jobs: jobsRes.data.items || [],
+                queues: queuesRes.data.items || [],
+                pods: podsRes.data.items || [],
             });
         } catch (error) {
             console.error("Error fetching dashboard data:", error);

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -4,8 +4,7 @@ import ErrorDisplay from "./ErrorDisplay";
 import DashboardHeader from "./DashboardHeader";
 import StatCardsContainer from "./StatCardsContainer";
 import ChartsContainer from "./ChartsContainer";
-import apiClient from "../../config/api";
-
+import apiClient, { API_ENDPOINTS } from "../../config/api";
 const Dashboard = () => {
     const [dashboardData, setDashboardData] = useState({
         jobs: [],
@@ -21,9 +20,9 @@ const Dashboard = () => {
         setError(null);
         try {
             const [jobsRes, queuesRes, podsRes] = await Promise.all([
-                apiClient.get("/jobs?limit=1000"),
-                apiClient.get("/queues?limit=1000"),
-                apiClient.get("/pods?limit=1000"),
+                apiClient.get(`${API_ENDPOINTS.jobs.list}?limit=1000`),
+                apiClient.get(`${API_ENDPOINTS.queues.list}?limit=1000`),
+                apiClient.get(`${API_ENDPOINTS.pods.list}?limit=1000`),
             ]);
 
             setDashboardData({

--- a/frontend/src/components/jobs/JobTable/JobTable.jsx
+++ b/frontend/src/components/jobs/JobTable/JobTable.jsx
@@ -12,6 +12,7 @@ import {
 import JobTableHeader from "./JobTableHeader";
 import JobTableRow from "./JobTableRow";
 import JobTableDeleteDialog from "./JobTableDeleteDialog"; // Be sure to have this component
+import apiClient, { API_ENDPOINTS } from "../../../config/api";
 
 const JobTable = ({
     jobs,
@@ -56,54 +57,23 @@ const JobTable = ({
         setIsDeleting(true);
         try {
             const { namespace, name } = jobToDelete.metadata;
-            const response = await fetch(
-                `/api/jobs/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
-                {
-                    method: "DELETE",
-                    headers: {
-                        "Content-Type": "application/json",
-                        Accept: "application/json",
-                    },
-                },
+            await apiClient.delete(
+                API_ENDPOINTS.jobs.detail(
+                    encodeURIComponent(namespace),
+                    encodeURIComponent(name),
+                ),
             );
 
-            // Try to parse the JSON error or success body
-            let data = {};
-            const contentType = response.headers.get("content-type");
-            const text = await response.text();
-            try {
-                if (
-                    contentType &&
-                    contentType.includes("application/json") &&
-                    text
-                ) {
-                    data = JSON.parse(text);
-                } else {
-                    data = { message: text };
-                }
-            } catch {
-                data = { message: text };
-            }
-
-            // If DELETE failed, show the message from K8s API (data.message or data.details)
-            if (!response.ok) {
-                // Prefer Kubernetes' error message or fallback to the raw response
-                const k8sMessage =
-                    data.message ||
-                    data.details ||
-                    text ||
-                    `Job "${namespace}/${name}" could not be deleted.`;
-
-                setDeleteError(k8sMessage);
-                return;
-            }
-
-            // On success, optionally reload jobs
             if (reloadJobs) reloadJobs();
-
             handleCloseDeleteDialog();
         } catch (error) {
-            setDeleteError(error.message || "An unexpected error occurred.");
+            const data = error.response?.data;
+            const k8sMessage =
+                data?.message ||
+                data?.details ||
+                error.message ||
+                `Job "${jobToDelete.metadata.namespace}/${jobToDelete.metadata.name}" could not be deleted.`;
+            setDeleteError(k8sMessage);
         } finally {
             setIsDeleting(false);
         }

--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
-import axios from "axios";
+import apiClient from "../../config/api";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces, fetchAllQueues } from "../utils";
 import JobTable from "./JobTable/JobTable";
@@ -42,7 +42,7 @@ const Jobs = () => {
         setError(null);
 
         try {
-            const response = await axios.get(`/api/jobs`, {
+            const response = await apiClient.get("/jobs", {
                 params: {
                     search: searchText,
                     namespace: filters.namespace,
@@ -51,13 +51,8 @@ const Jobs = () => {
                 },
             });
 
-            if (response.status !== 200) {
-                throw new Error(`HTTP error! status: ${response.status}`);
-            }
-
-            const data = response.data;
-            setCachedJobs(data.items || []);
-            setTotalJobs(data.totalCount || 0);
+            setCachedJobs(response.data.items || []);
+            setTotalJobs(response.data.totalCount || 0);
         } catch (err) {
             setError("Failed to fetch jobs: " + err.message);
             setCachedJobs([]);
@@ -86,14 +81,14 @@ const Jobs = () => {
     const handleClearSearch = () => {
         setSearchText("");
         setPagination((prev) => ({ ...prev, page: 1 }));
-        fetchJobs();
+        // removed fetchJobs() — useEffect handles re-fetch automatically
     };
 
     const handleJobClick = useCallback(async (job) => {
         try {
             setLoading(true);
-            const response = await axios.get(
-                `/api/job/${job.metadata.namespace}/${job.metadata.name}/yaml`,
+            const response = await apiClient.get(
+                `/job/${job.metadata.namespace}/${job.metadata.name}/yaml`,
                 { responseType: "text" },
             );
 
@@ -143,27 +138,11 @@ const Jobs = () => {
 
     const handleCreateJob = async (newJob) => {
         try {
-            const response = await fetch("/api/jobs", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(newJob),
-            });
-
-            if (!response.ok) {
-                let errorMsg = "Unknown error";
-                try {
-                    const errData = await response.json();
-                    errorMsg = errData.error || response.statusText;
-                } catch {
-                    // ignore error
-                }
-                alert("Error creating job: " + errorMsg);
-                return;
-            }
-
+            await apiClient.post("/jobs", newJob);
             alert("Job created successfully!");
         } catch (err) {
-            alert("Network error: " + err.message);
+            const errorMsg = err.response?.data?.error || err.message;
+            alert("Error creating job: " + errorMsg);
         }
     };
 
@@ -221,7 +200,7 @@ const Jobs = () => {
                     handleClearSearch={handleClearSearch}
                     handleRefresh={fetchJobs}
                     fetchData={fetchJobs}
-                    isRefreshing={false} // Update if needed
+                    isRefreshing={false}
                     placeholder="Search jobs..."
                     refreshLabel="Refresh Job Listings"
                     createlabel="Create Job"

--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
-import apiClient from "../../config/api";
+import apiClient, { API_ENDPOINTS } from "../../config/api";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces, fetchAllQueues } from "../utils";
 import JobTable from "./JobTable/JobTable";
@@ -42,7 +42,7 @@ const Jobs = () => {
         setError(null);
 
         try {
-            const response = await apiClient.get("/jobs", {
+            const response = await apiClient.get(API_ENDPOINTS.jobs.list, {
                 params: {
                     search: searchText,
                     namespace: filters.namespace,
@@ -88,10 +88,12 @@ const Jobs = () => {
         try {
             setLoading(true);
             const response = await apiClient.get(
-                `/job/${job.metadata.namespace}/${job.metadata.name}/yaml`,
+                API_ENDPOINTS.jobs.yaml(
+                    job.metadata.namespace,
+                    job.metadata.name,
+                ),
                 { responseType: "text" },
             );
-
             const formattedYaml = response.data
                 .split("\n")
                 .map((line) => {
@@ -138,7 +140,7 @@ const Jobs = () => {
 
     const handleCreateJob = async (newJob) => {
         try {
-            await apiClient.post("/jobs", newJob);
+            await apiClient.post(API_ENDPOINTS.jobs.list, newJob);
             alert("Job created successfully!");
         } catch (err) {
             const errorMsg = err.response?.data?.error || err.message;

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
-import axios from "axios";
-import SearchBar from "../Searchbar";
+import apiClient, { API_ENDPOINTS } from "../../config/api";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces } from "../utils";
 import PodsTable from "./PodsTable/PodsTable";
 import PodsPagination from "./PodsPagination";
 import PodDetailsDialog from "./PodDetailsDialog";
+import SearchBar from "../Searchbar";
 
 const Pods = () => {
     const [pods, setPods] = useState([]);
@@ -35,7 +35,7 @@ const Pods = () => {
         setError(null);
 
         try {
-            const response = await axios.get(`/api/pods`, {
+            const response = await apiClient.get(API_ENDPOINTS.pods.list, {
                 params: {
                     search: searchText,
                     namespace: filters.namespace,
@@ -88,11 +88,8 @@ const Pods = () => {
 
     const fetchData = async () => {
         try {
-            const response = await fetch("/api/pods");
-            if (response.ok) {
-                const data = await response.json();
-                setPods(data);
-            }
+            const response = await apiClient.get(API_ENDPOINTS.pods.list);
+            setPods(response.data);
         } catch (error) {
             console.error("Error fetching pods:", error);
         }
@@ -100,26 +97,9 @@ const Pods = () => {
 
     const handleCreatePod = async (newPod) => {
         try {
-            const response = await fetch("/api/pods", {
-                method: "POST",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify(newPod),
-            });
-
-            if (!response.ok) {
-                let errorMsg = "Unknown error";
-                try {
-                    const errData = await response.json();
-                    errorMsg = errData.error || response.statusText;
-                } catch {
-                    // ignore error
-                }
-                alert("Error creating pod: " + errorMsg);
-                return;
-            }
-
+            await apiClient.post(API_ENDPOINTS.pods.list, newPod);
             alert("Pod created successfully!");
-            await fetchData(); // Now fetchData is defined in the same scope
+            await fetchData();
         } catch (err) {
             alert("Network error: " + err.message);
         }
@@ -128,8 +108,8 @@ const Pods = () => {
     const handlePodClick = useCallback(async (pod) => {
         try {
             setLoading(true);
-            const response = await axios.get(
-                `/api/pod/${pod.metadata.namespace}/${pod.metadata.name}/yaml`,
+            const response = await apiClient.get(
+                `/pod/${pod.metadata.namespace}/${pod.metadata.name}/yaml`,
                 { responseType: "text" },
             );
 

--- a/frontend/src/components/queues/QueueTable/EditQueueDialog.jsx
+++ b/frontend/src/components/queues/QueueTable/EditQueueDialog.jsx
@@ -16,7 +16,7 @@ import {
 } from "@mui/material";
 import Editor from "@monaco-editor/react";
 import yaml from "js-yaml";
-import apiClient, { API_ENDPOINTS } from "../../config/api";
+import apiClient, { API_ENDPOINTS } from "../../../config/api";
 
 const RenderFields = ({ data, onChange, path = [] }) =>
     Object.entries(data || {}).map(([key, value]) => {

--- a/frontend/src/components/queues/QueueTable/EditQueueDialog.jsx
+++ b/frontend/src/components/queues/QueueTable/EditQueueDialog.jsx
@@ -16,6 +16,7 @@ import {
 } from "@mui/material";
 import Editor from "@monaco-editor/react";
 import yaml from "js-yaml";
+import apiClient, { API_ENDPOINTS } from "../../config/api";
 
 const RenderFields = ({ data, onChange, path = [] }) =>
     Object.entries(data || {}).map(([key, value]) => {
@@ -91,7 +92,6 @@ const RenderFields = ({ data, onChange, path = [] }) =>
             );
         }
 
-        // Render checkbox for booleans
         if (typeof value === "boolean") {
             return (
                 <FormControlLabel
@@ -110,7 +110,6 @@ const RenderFields = ({ data, onChange, path = [] }) =>
             );
         }
 
-        // For other primitives, convert strings "true"/"false" to boolean, numbers too
         return (
             <TextField
                 key={currentPath.join(".")}
@@ -148,11 +147,9 @@ const EditQueueDialog = ({ open, queue, onClose, onSave }) => {
     const [formState, setFormState] = useState({});
     const [saving, setSaving] = useState(false);
 
-    // Refs to avoid infinite loops when syncing form & YAML
     const skipYamlUpdate = useRef(false);
     const skipFormUpdate = useRef(false);
 
-    // Load initial data on open
     useEffect(() => {
         if (open && queue) {
             const dumpedYaml = yaml.dump(queue);
@@ -162,7 +159,6 @@ const EditQueueDialog = ({ open, queue, onClose, onSave }) => {
         }
     }, [open, queue]);
 
-    // Sync YAML editor -> formState (parse YAML)
     useEffect(() => {
         if (skipYamlUpdate.current) {
             skipYamlUpdate.current = false;
@@ -177,7 +173,6 @@ const EditQueueDialog = ({ open, queue, onClose, onSave }) => {
         }
     }, [editorValue]);
 
-    // Sync formState -> YAML editor (stringify)
     useEffect(() => {
         if (skipFormUpdate.current) {
             skipFormUpdate.current = false;
@@ -216,29 +211,18 @@ const EditQueueDialog = ({ open, queue, onClose, onSave }) => {
 
             setSaving(true);
 
-            const resp = await fetch(`/api/queues/${updated.metadata.name}`, {
-                method: "PUT",
-                headers: { "Content-Type": "application/json" },
-                body: JSON.stringify({ spec: updated.spec }),
-            });
+            const response = await apiClient.put(
+                `${API_ENDPOINTS.queues.list}/${updated.metadata.name}`,
+                { spec: updated.spec },
+            );
 
-            if (!resp.ok) {
-                const contentType = resp.headers.get("content-type");
-                const errText = contentType?.includes("application/json")
-                    ? (await resp.json()).details || "Unknown error"
-                    : await resp.text();
-                throw new Error(errText);
-            }
+            const responseData = response.data;
 
-            const responseData = await resp.json();
-
-            // Update local state with the response data from server
             const fullUpdatedQueue = {
                 ...updated,
                 spec: responseData.spec || updated.spec,
             };
 
-            // Prevent infinite loops while syncing
             skipFormUpdate.current = true;
             setFormState(fullUpdatedQueue);
             skipYamlUpdate.current = true;
@@ -251,7 +235,14 @@ const EditQueueDialog = ({ open, queue, onClose, onSave }) => {
             onClose();
         } catch (err) {
             console.error("Save failed:", err);
-            alert(err.message || "Failed to save");
+            const errMsg =
+                err.response?.data?.details ||
+                err.response?.data?.message ||
+                err.message ||
+                "Failed to save";
+            alert(errMsg);
+        } finally {
+            setSaving(false);
         }
     };
 

--- a/frontend/src/components/queues/QueueTable/EditQueueDialog.jsx
+++ b/frontend/src/components/queues/QueueTable/EditQueueDialog.jsx
@@ -212,7 +212,7 @@ const EditQueueDialog = ({ open, queue, onClose, onSave }) => {
             setSaving(true);
 
             const response = await apiClient.put(
-                `${API_ENDPOINTS.queues.list}/${updated.metadata.name}`,
+                API_ENDPOINTS.queues.detail(updated.metadata.name),
                 { spec: updated.spec },
             );
 

--- a/frontend/src/components/queues/QueueTable/QueueTable.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTable.jsx
@@ -12,6 +12,7 @@ import {
 import QueueTableHeader from "./QueueTableHeader";
 import QueueTableRow from "./QueueTableRow";
 import QueueTableDeleteDialog from "./QueueTableDeleteDialog";
+import apiClient, { API_ENDPOINTS } from "../../config/api";
 
 const QueueTable = ({
     sortedQueues,
@@ -39,6 +40,7 @@ const QueueTable = ({
     const [queueToDelete, setQueueToDelete] = useState(null);
     const [deleteError, setDeleteError] = useState(null);
     const [isDeleting, setIsDeleting] = useState(false);
+
     const handleOpenDeleteDialog = (queueName) => {
         setQueueToDelete(queueName);
         setOpenDeleteDialog(true);
@@ -55,66 +57,24 @@ const QueueTable = ({
         try {
             setIsDeleting(true);
 
-            const response = await fetch(
-                `/api/queues/${encodeURIComponent(queueToDelete)}`,
-                {
-                    method: "DELETE",
-                    headers: {
-                        "Content-Type": "application/json",
-                        Accept: "application/json",
-                    },
-                },
+            await apiClient.delete(
+                `${API_ENDPOINTS.queues.list}/${encodeURIComponent(queueToDelete)}`
             );
 
-            let data = {};
-            const contentType = response.headers.get("content-type");
-            const text = await response.text();
-
-            let isJsonResponse = false;
-            try {
-                if (
-                    (contentType && contentType.includes("application/json")) ||
-                    (text && !text.trim().startsWith("<"))
-                ) {
-                    data = text ? JSON.parse(text) : {};
-                    isJsonResponse = true;
-                }
-            } catch (parseError) {
-                console.warn("Failed to parse response as JSON:", parseError);
-            }
-
-            if (!response.ok) {
-                let customMessage = `queues.scheduling.volcano.sh "${queueToDelete}" is forbidden.`;
-                let errorType = "UnknownError";
-
-                if (
-                    isJsonResponse &&
-                    typeof data === "object" &&
-                    (data.message || data.details)
-                ) {
-                    customMessage = data.message || data.details;
-                    if (customMessage.toLowerCase().includes("denied")) {
-                        errorType = "ValidationError";
-                    } else {
-                        errorType = "KubernetesError";
-                    }
-                }
-
-                const fullMessage = `Cannot delete "${queueToDelete}". Error message: ${customMessage}`;
-                const error = new Error(fullMessage);
-                error.type = errorType;
-                error.status = response.status;
-                throw error;
-            }
-
-            // Success
             setQueues((prev) =>
                 prev.filter((queue) => queue.metadata.name !== queueToDelete),
             );
             handleCloseDeleteDialog();
         } catch (error) {
             console.error("Error deleting queue:", error);
-            setDeleteError(error.message || "An unexpected error occurred.");
+            const data = error.response?.data;
+            const customMessage =
+                data?.message ||
+                data?.details ||
+                error.message ||
+                `queues.scheduling.volcano.sh "${queueToDelete}" is forbidden.`;
+            const fullMessage = `Cannot delete "${queueToDelete}". Error message: ${customMessage}`;
+            setDeleteError(fullMessage);
         } finally {
             setIsDeleting(false);
         }

--- a/frontend/src/components/queues/QueueTable/QueueTable.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTable.jsx
@@ -57,9 +57,7 @@ const QueueTable = ({
         try {
             setIsDeleting(true);
 
-            await apiClient.delete(
-                `${API_ENDPOINTS.queues.list}/${encodeURIComponent(queueToDelete)}`
-            );
+            await apiClient.delete(API_ENDPOINTS.queues.detail(queueToDelete));
 
             setQueues((prev) =>
                 prev.filter((queue) => queue.metadata.name !== queueToDelete),

--- a/frontend/src/components/queues/QueueTable/QueueTable.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTable.jsx
@@ -12,7 +12,7 @@ import {
 import QueueTableHeader from "./QueueTableHeader";
 import QueueTableRow from "./QueueTableRow";
 import QueueTableDeleteDialog from "./QueueTableDeleteDialog";
-import apiClient, { API_ENDPOINTS } from "../../config/api";
+import apiClient, { API_ENDPOINTS } from "../../../config/api";
 
 const QueueTable = ({
     sortedQueues,

--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -1,8 +1,8 @@
-import apiClient from "../config/api";
+import apiClient, { API_ENDPOINTS } from "../config/api";
 
 export const fetchAllNamespaces = async () => {
     try {
-        const response = await apiClient.get("/namespaces");
+        const response = await apiClient.get(API_ENDPOINTS.namespaces.list);
         return [
             "All",
             ...new Set(response.data.items.map((item) => item.metadata.name)),
@@ -15,7 +15,7 @@ export const fetchAllNamespaces = async () => {
 
 export const fetchAllQueues = async () => {
     try {
-        const response = await apiClient.get("/all-queues");
+        const response = await apiClient.get(API_ENDPOINTS.queues.all);
         return [
             "All",
             ...new Set(response.data.items.map((item) => item.metadata.name)),

--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -1,15 +1,11 @@
+import apiClient from "../config/api";
+
 export const fetchAllNamespaces = async () => {
     try {
-        const response = await fetch(`/api/namespaces`);
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const data = await response.json();
-
+        const response = await apiClient.get("/namespaces");
         return [
             "All",
-            ...new Set(data.items.map((item) => item.metadata.name)),
+            ...new Set(response.data.items.map((item) => item.metadata.name)),
         ];
     } catch (error) {
         console.error("Error fetching namespaces:", error);
@@ -19,16 +15,10 @@ export const fetchAllNamespaces = async () => {
 
 export const fetchAllQueues = async () => {
     try {
-        const response = await fetch(`/api/all-queues`);
-        if (!response.ok) {
-            throw new Error(`HTTP error! status: ${response.status}`);
-        }
-
-        const data = await response.json();
-
+        const response = await apiClient.get("/all-queues");
         return [
             "All",
-            ...new Set(data.items.map((item) => item.metadata.name)),
+            ...new Set(response.data.items.map((item) => item.metadata.name)),
         ];
     } catch (error) {
         console.error("Error fetching queues:", error);
@@ -69,5 +59,5 @@ export const parseMemoryToMi = (memoryStr) => {
     if (memoryStr.includes("Gi")) return value * 1024;
     if (memoryStr.includes("Mi")) return value;
     if (memoryStr.includes("Ki")) return value / 1024;
-    return value / 1024 / 1024; // default Bi
+    return value / 1024 / 1024;
 };

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,29 +1,24 @@
-// Prioritize using the port in the environment variable, if not, use the default port 3001
-const getServerPort = () => {
-    return process.env.APP_SERVER_PORT || "3001";
-};
+import axios from 'axios'
 
-// Build API base URL
-const API_CONFIG = {
-    baseURL: `http://localhost:${getServerPort()}`,
-};
+// Single axios instance — works in dev (Vite proxy) and production (Nginx)
+const apiClient = axios.create({
+    baseURL: '/api'
+})
 
-//API endpoint configuration
 export const API_ENDPOINTS = {
     jobs: {
-        list: `${API_CONFIG.baseURL}/api/jobs`,
-        detail: (namespace, name) =>
-            `${API_CONFIG.baseURL}/jobs/${namespace}/${name}`,
+        list: '/jobs',
+        detail: (namespace, name) => `/jobs/${namespace}/${name}`,
     },
     queues: {
-        list: `${API_CONFIG.baseURL}/api/queues`,
+        list: '/queues',
     },
     pods: {
-        list: `${API_CONFIG.baseURL}/api/pods`,
+        list: '/pods',
     },
     podgroups: {
-        list: `${API_CONFIG.baseURL}/api/podgroups`,
+        list: '/podgroups',
     },
-};
+}
 
-export default API_CONFIG;
+export default apiClient

--- a/frontend/src/config/api.js
+++ b/frontend/src/config/api.js
@@ -1,6 +1,5 @@
 import axios from 'axios'
 
-// Single axios instance — works in dev (Vite proxy) and production (Nginx)
 const apiClient = axios.create({
     baseURL: '/api'
 })
@@ -8,16 +7,24 @@ const apiClient = axios.create({
 export const API_ENDPOINTS = {
     jobs: {
         list: '/jobs',
-        detail: (namespace, name) => `/jobs/${namespace}/${name}`,
+        detail: (namespace, name) => `/jobs/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}`,
+        yaml: (namespace, name) => `/job/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/yaml`,
     },
     queues: {
         list: '/queues',
+        all: '/all-queues',
+        detail: (name) => `/queues/${encodeURIComponent(name)}`,
     },
     pods: {
         list: '/pods',
+        yaml: (namespace, name) => `/pod/${encodeURIComponent(namespace)}/${encodeURIComponent(name)}/yaml`,
+
     },
     podgroups: {
         list: '/podgroups',
+    },
+    namespaces: {
+        list: '/namespaces',
     },
 }
 


### PR DESCRIPTION
## Problem
`src/config/api.js` was created to centralize API configuration but was effectively dead code. It used `process.env.APP_SERVER_PORT` (not supported in Vite), hardcoded `http://localhost:3001` as the base URL (breaking staging and production), and was never imported by any component.

## Solution
Rewrote `api.js` as a single shared axios instance with `baseURL: '/api'` and migrated all direct `fetch`/`axios` calls across the frontend to use it.

Fixes #263 

## Changes
- Replaced broken `process.env` + hardcoded localhost URL in `api.js` with a shared axios instance (`baseURL: '/api'`)
- Updated `API_ENDPOINTS` to use relative paths
- Replaced all direct `fetch`/`axios` calls with `apiClient` in:
  - `Dashboard.jsx`
  - `Jobs.jsx`
  - `JobTable.jsx`
  - `Pods.jsx`
  - `QueueTable.jsx`
  - `EditQueueDialog.jsx`
  - `utils.js`