### PR TITLE
feat: translate volcano dashboard into chinese

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,9 @@
         "bootstrap": "^5.3.5",
         "chart.js": "^4.4.7",
         "dotenv": "^16.4.7",
+        "i18next": "^26.2.0",
+        "i18next-browser-languagedetector": "^8.2.1",
+        "i18next-http-backend": "^4.0.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "lucide-react": "^0.511.0",
@@ -32,6 +35,7 @@
         "react-bootstrap": "^2.10.9",
         "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
+        "react-i18next": "^17.0.8",
         "react-router-dom": "^7.1.5"
     },
     "devDependencies": {

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -1,0 +1,41 @@
+{
+  "dashboard": {
+    "title": "Volcano Dashboard",
+    "refresh": "Refresh Data",
+    "totalJobs": "Total Jobs",
+    "activeQueues": "Active Queues",
+    "runningPods": "Running Pods",
+    "completeRate": "Complete Rate",
+    "jobsStatus": "Jobs Status",
+    "noData": "No data available",
+    "queueResources": "Queue Resources",
+    "noDataForResource": "No data available for selected resource type",
+    "allocated": "Allocated",
+    "capacity": "Capacity",
+    "amount": "Amount",
+    "memory": "Memory (Gi)",
+    "cpu": "CPU Cores",
+    "pods": "Pod Count",
+    "gpu": "GPU Count",
+    "nvidiaGpu": "GPU Count",
+    "status": {
+      "Completed": "Completed",
+      "Running": "Running",
+      "Failed": "Failed"
+    },
+    "apiError": {
+      "jobs": "Jobs API error: {{status}}",
+      "queues": "Queues API error: {{status}}",
+      "pods": "Pods API error: {{status}}",
+      "network": "Network or API request failed. Please check if the backend service is running."
+    }
+  },
+  "pods": {
+    "pagination": {
+      "perPage_5": "5 per page",
+      "perPage_10": "10 per page",
+      "perPage_20": "20 per page",
+      "totalPods": "Total Pods: {{count}}"
+    }
+  }
+}

--- a/frontend/public/locales/zh/translation.json
+++ b/frontend/public/locales/zh/translation.json
@@ -1,0 +1,41 @@
+{
+  "dashboard": {
+    "title": "火山仪表盘",
+    "refresh": "刷新数据",
+    "totalJobs": "作业总数",
+    "activeQueues": "活动队列数",
+    "runningPods": "运行中的容器组数",
+    "completeRate": "完成率",
+    "jobsStatus": "作业状态",
+    "noData": "暂无数据",
+    "queueResources": "队列资源",
+    "noDataForResource": "选定资源类型无可用数据",
+    "allocated": "已分配",
+    "capacity": "容量",
+    "amount": "数量",
+    "memory": "内存 (Gi)",
+    "cpu": "CPU 核数",
+    "pods": "容器组数量",
+    "gpu": "GPU 数量",
+    "nvidiaGpu": "GPU 数量",
+    "status": {
+      "Completed": "已完成",
+      "Running": "运行中",
+      "Failed": "已失败"
+    },
+    "apiError": {
+      "jobs": "作业应用程序接口错误: {{status}}",
+      "queues": "队列应用程序接口错误: {{status}}",
+      "pods": "容器组应用程序接口错误: {{status}}",
+      "network": "网络或接口请求失败，请检查后端服务是否正常运行。"
+    }
+  },
+  "pods": {
+    "pagination": {
+      "perPage_5": "每页 5 条",
+      "perPage_10": "每页 10 条",
+      "perPage_20": "每页 20 条",
+      "totalPods": "容器组总数：{{count}}"
+    }
+  }
+}

--- a/frontend/src/components/Charts/JobStatusPieChart.jsx
+++ b/frontend/src/components/Charts/JobStatusPieChart.jsx
@@ -1,15 +1,18 @@
 import React from "react";
 import { Box, Typography } from "@mui/material";
 import { Doughnut } from "react-chartjs-2";
+import { useTranslation } from "react-i18next";
 import { Chart as ChartJS, ArcElement, Tooltip, Legend, Title } from "chart.js";
 
 ChartJS.register(ArcElement, Tooltip, Legend, Title);
 
 const JobStatusPieChart = ({ data }) => {
+    const { t } = useTranslation();
+
     if (!data || !Array.isArray(data)) {
         return (
             <Box sx={{ height: 300, width: "100%", position: "relative" }}>
-                <Typography>No data available</Typography>
+                <Typography>{t("dashboard.noData")}</Typography>
             </Box>
         );
     }
@@ -44,7 +47,9 @@ const JobStatusPieChart = ({ data }) => {
     };
 
     const chartData = {
-        labels: Object.keys(statusCounts),
+        labels: Object.keys(statusCounts).map((status) =>
+            t(`dashboard.status.${status}`),
+        ),
         datasets: [
             {
                 data: Object.values(statusCounts),
@@ -80,7 +85,7 @@ const JobStatusPieChart = ({ data }) => {
             }}
         >
             <Typography variant="h6" align="center" sx={{ mb: 1 }}>
-                Jobs Status
+                {t("dashboard.jobsStatus")}
             </Typography>
 
             <Box
@@ -159,7 +164,7 @@ const JobStatusPieChart = ({ data }) => {
                                 variant="body2"
                                 sx={{ mr: 2, minWidth: 70 }}
                             >
-                                {status}
+                                {t(`dashboard.status.${status}`)}
                             </Typography>
                             <Typography variant="body2" color="text.secondary">
                                 {count} (

--- a/frontend/src/components/Charts/QueueResourcesBarChart.jsx
+++ b/frontend/src/components/Charts/QueueResourcesBarChart.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { Box, FormControl, MenuItem, Select, Typography } from "@mui/material";
 import { Bar } from "react-chartjs-2";
+import { useTranslation } from "react-i18next";
 import "./chartConfig";
 
 const convertMemoryToGi = (memoryStr) => {
@@ -54,6 +55,7 @@ const processData = (data) => {
 };
 
 const QueueResourcesBarChart = ({ data }) => {
+    const { t } = useTranslation();
     const [selectedResource, setSelectedResource] = useState("");
 
     // Obtain resource type options dynamically
@@ -71,11 +73,19 @@ const QueueResourcesBarChart = ({ data }) => {
         });
 
         // Convert resource type from Set to Array
-        return Array.from(resourceTypes).map((resource) => ({
-            value: resource,
-            label: `${resource.charAt(0).toUpperCase() + resource.slice(1)} Resources`,
-        }));
-    }, [data]);
+        return Array.from(resourceTypes).map((resource) => {
+            let label = `${resource.charAt(0).toUpperCase() + resource.slice(1)} Resources`;
+            if (resource === "memory") label = t("dashboard.memory");
+            else if (resource === "cpu") label = t("dashboard.cpu");
+            else if (resource === "pods") label = t("dashboard.pods");
+            else if (resource === "nvidia.com/gpu") label = t("dashboard.gpu");
+
+            return {
+                value: resource,
+                label: label,
+            };
+        });
+    }, [data, t]);
 
     useEffect(() => {
         // If there is a resource option, the first resource is selected by default
@@ -92,7 +102,7 @@ const QueueResourcesBarChart = ({ data }) => {
         labels: Object.keys(processedData),
         datasets: [
             {
-                label: `${selectedResource.toUpperCase()} Allocated`,
+                label: `${selectedResource.toUpperCase()} ${t("dashboard.allocated")}`,
                 data: Object.values(processedData).map(
                     (q) => q.allocated[selectedResource] || 0,
                 ),
@@ -101,7 +111,7 @@ const QueueResourcesBarChart = ({ data }) => {
                 borderWidth: 1,
             },
             {
-                label: `${selectedResource.toUpperCase()} Capacity`,
+                label: `${selectedResource.toUpperCase()} ${t("dashboard.capacity")}`,
                 data: Object.values(processedData).map(
                     (q) => q.capability[selectedResource] || 0,
                 ),
@@ -116,15 +126,15 @@ const QueueResourcesBarChart = ({ data }) => {
     const getYAxisLabel = () => {
         switch (selectedResource) {
             case "memory":
-                return "Memory (Gi)";
+                return t("dashboard.memory");
             case "cpu":
-                return "CPU Cores";
+                return t("dashboard.cpu");
             case "pods":
-                return "Pod Count";
+                return t("dashboard.pods");
             case "nvidia.com/gpu":
-                return "GPU Count";
+                return t("dashboard.gpu");
             default:
-                return "Amount";
+                return t("dashboard.amount");
         }
     };
 
@@ -175,7 +185,7 @@ const QueueResourcesBarChart = ({ data }) => {
                     mb: 2,
                 }}
             >
-                <Typography variant="h6">Queue Resources</Typography>
+                <Typography variant="h6">{t("dashboard.queueResources")}</Typography>
                 <FormControl size="small" sx={{ minWidth: 150 }}>
                     <Select
                         value={selectedResource}
@@ -203,7 +213,7 @@ const QueueResourcesBarChart = ({ data }) => {
                         color="text.secondary"
                         sx={{ mt: 4 }}
                     >
-                        No data available for selected resource type
+                        {t("dashboard.noDataForResource")}
                     </Typography>
                 )}
             </Box>

--- a/frontend/src/components/dashboard/Dashboard.jsx
+++ b/frontend/src/components/dashboard/Dashboard.jsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from "react";
 import { Box } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import ErrorDisplay from "./ErrorDisplay";
 import DashboardHeader from "./DashboardHeader";
 import StatCardsContainer from "./StatCardsContainer";
 import ChartsContainer from "./ChartsContainer";
 
 const Dashboard = () => {
+    const { t } = useTranslation();
     const [dashboardData, setDashboardData] = useState({
         jobs: [],
         queues: [],
@@ -26,11 +28,11 @@ const Dashboard = () => {
             ]);
 
             if (!jobsRes.ok)
-                throw new Error(`Jobs API error: ${jobsRes.status}`);
+                throw { key: "dashboard.apiError.jobs", params: { status: jobsRes.status } };
             if (!queuesRes.ok)
-                throw new Error(`Queues API error: ${queuesRes.status}`);
+                throw { key: "dashboard.apiError.queues", params: { status: queuesRes.status } };
             if (!podsRes.ok)
-                throw new Error(`Pods API error: ${podsRes.status}`);
+                throw { key: "dashboard.apiError.pods", params: { status: podsRes.status } };
 
             const [jobsData, queuesData, podsData] = await Promise.all([
                 jobsRes.json(),
@@ -43,9 +45,20 @@ const Dashboard = () => {
                 queues: queuesData.items || [],
                 pods: podsData.items || [],
             });
-        } catch (error) {
-            console.error("Error fetching dashboard data:", error);
-            setError(error.message);
+        } catch (err) {
+            console.error("Error fetching dashboard data:", err);
+            // If the error has a translation key (our custom throws)
+            if (err.key) {
+                setError(err);
+            } 
+            // fetch() throws a TypeError on network failures (e.g., connection refused)
+            else if (err.name === "TypeError" || err.message === "Failed to fetch") {
+                setError({ key: "dashboard.apiError.network" });
+            } 
+            // Fallback for other arbitrary errors
+            else {
+                setError({ message: err.message });
+            }
         } finally {
             setRefreshing(false);
             setIsLoading(false);
@@ -60,6 +73,12 @@ const Dashboard = () => {
         fetchAllData();
     }, []);
 
+    const getErrorMessage = () => {
+        if (!error) return null;
+        if (error.key) return t(error.key, error.params);
+        return error.message;
+    };
+
     return (
         <Box
             sx={{
@@ -69,7 +88,7 @@ const Dashboard = () => {
                 p: 3,
             }}
         >
-            {error && <ErrorDisplay message={error} />}
+            {error && <ErrorDisplay message={getErrorMessage()} />}
 
             <DashboardHeader
                 onRefresh={handleRefresh}

--- a/frontend/src/components/dashboard/DashboardHeader.jsx
+++ b/frontend/src/components/dashboard/DashboardHeader.jsx
@@ -1,9 +1,18 @@
 import React from "react";
-import { Box, IconButton, Tooltip } from "@mui/material";
+import { Box, IconButton, Tooltip, Button } from "@mui/material";
 import RefreshIcon from "@mui/icons-material/Refresh";
+import TranslateIcon from "@mui/icons-material/Translate";
+import { useTranslation } from "react-i18next";
 import TitleComponent from "../Titlecomponent";
 
 const DashboardHeader = ({ onRefresh, refreshing }) => {
+    const { t, i18n } = useTranslation();
+
+    const toggleLanguage = () => {
+        const nextLang = i18n.language.startsWith("zh") ? "en" : "zh";
+        i18n.changeLanguage(nextLang);
+    };
+
     return (
         <Box
             sx={{
@@ -13,12 +22,31 @@ const DashboardHeader = ({ onRefresh, refreshing }) => {
                 mb: 3,
             }}
         >
-            <TitleComponent text="Volcano Dashboard" />
-            <Tooltip title="Refresh Data">
-                <IconButton onClick={onRefresh} disabled={refreshing}>
-                    <RefreshIcon />
-                </IconButton>
-            </Tooltip>
+            <TitleComponent text={t("dashboard.title")} />
+            <Box sx={{ display: "flex", alignItems: "center", gap: 1 }}>
+                <Button
+                    variant="outlined"
+                    size="small"
+                    startIcon={<TranslateIcon />}
+                    onClick={toggleLanguage}
+                    sx={{
+                        textTransform: "none",
+                        fontWeight: 500,
+                        color: "text.secondary",
+                        borderColor: "divider",
+                        "&:hover": {
+                            borderColor: "primary.main",
+                        },
+                    }}
+                >
+                    {i18n.language.startsWith("zh") ? "中 / EN" : "EN / 中"}
+                </Button>
+                <Tooltip title={t("dashboard.refresh")}>
+                    <IconButton onClick={onRefresh} disabled={refreshing}>
+                        <RefreshIcon />
+                    </IconButton>
+                </Tooltip>
+            </Box>
         </Box>
     );
 };

--- a/frontend/src/components/dashboard/StatCardsContainer.jsx
+++ b/frontend/src/components/dashboard/StatCardsContainer.jsx
@@ -1,9 +1,11 @@
 import React from "react";
 import { Grid } from "@mui/material";
+import { useTranslation } from "react-i18next";
 import StatCard from "../Charts/StatCard";
 import { calculateSuccessRate } from "./utils";
 
 const StatCardsContainer = ({ jobs, queues, pods }) => {
+    const { t } = useTranslation();
     const activeQueues =
         queues.filter((q) => q.status?.state === "Open").length || 0;
     const runningPods =
@@ -13,16 +15,16 @@ const StatCardsContainer = ({ jobs, queues, pods }) => {
     return (
         <Grid container spacing={3} sx={{ mb: 3 }}>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Total Jobs" value={jobs?.length || 0} />
+                <StatCard title={t("dashboard.totalJobs")} value={jobs?.length || 0} />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Active Queues" value={activeQueues} />
+                <StatCard title={t("dashboard.activeQueues")} value={activeQueues} />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Running Pods" value={runningPods} />
+                <StatCard title={t("dashboard.runningPods")} value={runningPods} />
             </Grid>
             <Grid item xs={12} sm={6} md={3}>
-                <StatCard title="Complete Rate" value={`${successRate}%`} />
+                <StatCard title={t("dashboard.completeRate")} value={`${successRate}%`} />
             </Grid>
         </Grid>
     );

--- a/frontend/src/i18n.js
+++ b/frontend/src/i18n.js
@@ -1,0 +1,20 @@
+import i18n from "i18next";
+import { initReactI18next } from "react-i18next";
+import Backend from "i18next-http-backend";
+import LanguageDetector from "i18next-browser-languagedetector";
+
+i18n.use(Backend)
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+        fallbackLng: "en",
+        debug: false,
+        interpolation: {
+            escapeValue: false, // not needed for react as it escapes by default
+        },
+        backend: {
+            loadPath: "/locales/{{lng}}/translation.json",
+        },
+    });
+
+export default i18n;

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
-import { StrictMode } from "react";
+import { StrictMode, Suspense } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import "./i18n";
 import App from "./App.jsx";
 
 createRoot(document.getElementById("root")).render(
     <StrictMode>
-        <App />
+        <Suspense fallback="Loading...">
+            <App />
+        </Suspense>
     </StrictMode>,
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -89,6 +89,9 @@
                 "bootstrap": "^5.3.5",
                 "chart.js": "^4.4.7",
                 "dotenv": "^16.4.7",
+                "i18next": "^26.2.0",
+                "i18next-browser-languagedetector": "^8.2.1",
+                "i18next-http-backend": "^4.0.0",
                 "js-yaml": "^4.1.0",
                 "lodash": "^4.17.21",
                 "lucide-react": "^0.511.0",
@@ -96,6 +99,7 @@
                 "react-bootstrap": "^2.10.9",
                 "react-chartjs-2": "^5.3.0",
                 "react-dom": "^19.0.0",
+                "react-i18next": "^17.0.8",
                 "react-router-dom": "^7.1.5"
             },
             "devDependencies": {
@@ -307,7 +311,6 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -1966,9 +1969,9 @@
             }
         },
         "node_modules/@babel/runtime": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
-            "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -2107,7 +2110,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -2131,7 +2133,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -2899,6 +2900,7 @@
             "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-7.1.0.tgz",
             "integrity": "sha512-l/BQM7fYntsCI//du+6sEnHOP6a74UixFyOYUyz2DLMXKx+6DEhfR3F2NYGE45XH1JJuIamacb4IZs9S0ZOWLA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -2980,6 +2982,7 @@
             "deprecated": "Use @eslint/config-array instead",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@humanwhocodes/object-schema": "^2.0.3",
                 "debug": "^4.3.1",
@@ -3009,7 +3012,8 @@
             "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
             "deprecated": "Use @eslint/object-schema instead",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@humanwhocodes/retry": {
             "version": "0.4.3",
@@ -3306,7 +3310,6 @@
             "resolved": "https://registry.npmjs.org/@mui/material/-/material-6.5.0.tgz",
             "integrity": "sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/runtime": "^7.26.0",
                 "@mui/core-downloads-tracker": "^6.5.0",
@@ -3603,7 +3606,6 @@
             "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
             "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/popperjs"
@@ -4090,7 +4092,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -4300,7 +4301,6 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -4311,7 +4311,6 @@
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -4339,7 +4338,8 @@
             "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
             "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/@types/warning": {
             "version": "3.0.3",
@@ -4506,7 +4506,8 @@
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
             "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
             "dev": true,
-            "license": "ISC"
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/@vitejs/plugin-react": {
             "version": "4.7.0",
@@ -4535,7 +4536,6 @@
             "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/user-event": "^14.6.1",
@@ -4722,7 +4722,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -5397,7 +5396,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5580,7 +5578,6 @@
             "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
             "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@kurkle/color": "^0.3.0"
             },
@@ -6270,6 +6267,7 @@
             "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
             "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
             "license": "(MPL-2.0 OR Apache-2.0)",
+            "peer": true,
             "optionalDependencies": {
                 "@types/trusted-types": "^2.0.7"
             }
@@ -6821,6 +6819,7 @@
             "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -6845,6 +6844,7 @@
             "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -6855,6 +6855,7 @@
             "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "esutils": "^2.0.2"
             },
@@ -6868,6 +6869,7 @@
             "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -6885,6 +6887,7 @@
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -6898,6 +6901,7 @@
             "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "acorn": "^8.9.0",
                 "acorn-jsx": "^5.3.2",
@@ -6916,6 +6920,7 @@
             "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flat-cache": "^3.0.4"
             },
@@ -6929,6 +6934,7 @@
             "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
                 "keyv": "^4.5.3",
@@ -6944,6 +6950,7 @@
             "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -7752,7 +7759,8 @@
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -7892,6 +7900,15 @@
                 "node": ">=18"
             }
         },
+        "node_modules/html-parse-stringify": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+            "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+            "license": "MIT",
+            "dependencies": {
+                "void-elements": "3.1.0"
+            }
+        },
         "node_modules/http-errors": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7964,6 +7981,52 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
+            }
+        },
+        "node_modules/i18next": {
+            "version": "26.2.0",
+            "resolved": "https://registry.npmjs.org/i18next/-/i18next-26.2.0.tgz",
+            "integrity": "sha512-zwBHldHdTmwN7r6UNc7lC6GWNN+YYg3DrRSeHR5PRRBf5QnJZcYHrQc0uaU26qZeYxR7iFZD+Y315dPnKP47wA==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com/i18next"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.locize.com"
+                }
+            ],
+            "license": "MIT",
+            "peerDependencies": {
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/i18next-browser-languagedetector": {
+            "version": "8.2.1",
+            "resolved": "https://registry.npmjs.org/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz",
+            "integrity": "sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.23.2"
+            }
+        },
+        "node_modules/i18next-http-backend": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/i18next-http-backend/-/i18next-http-backend-4.0.0.tgz",
+            "integrity": "sha512-EgSjO3Q1G6f2Q5oy7u9mmxuesE0oSfzAD97NFBjC8EmkK4guBSYLljM0Fng3DarMWIIkU70jfo4+mUzmyVISTA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/iconv-lite": {
@@ -8719,7 +8782,6 @@
             "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
             "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 10.16.0"
             }
@@ -9171,6 +9233,7 @@
             "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
             "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "marked": "bin/marked.js"
             },
@@ -10565,7 +10628,6 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -10616,12 +10678,38 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
             "peerDependencies": {
                 "react": "^19.2.3"
+            }
+        },
+        "node_modules/react-i18next": {
+            "version": "17.0.8",
+            "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-17.0.8.tgz",
+            "integrity": "sha512-0ooKbGLU8JXhe1zwpQUWIeXSgLPOfwJmgheWRIUpcoA0CpyabpGhayjdG+/eA5esC1AQ8h2jWpXjJfzQzeDOCw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/runtime": "^7.29.2",
+                "html-parse-stringify": "^3.0.1",
+                "use-sync-external-store": "^1.6.0"
+            },
+            "peerDependencies": {
+                "i18next": ">= 26.2.0",
+                "react": ">= 16.8.0",
+                "typescript": "^5 || ^6"
+            },
+            "peerDependenciesMeta": {
+                "react-dom": {
+                    "optional": true
+                },
+                "react-native": {
+                    "optional": true
+                },
+                "typescript": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-is": {
@@ -10946,6 +11034,7 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -12181,7 +12270,8 @@
             "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
             "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tinybench": {
             "version": "2.9.0",
@@ -12238,7 +12328,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12422,6 +12511,7 @@
             "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
             "dev": true,
             "license": "(MIT OR CC0-1.0)",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -12524,7 +12614,7 @@
             "version": "5.9.3",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
             "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "dev": true,
+            "devOptional": true,
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
@@ -12675,6 +12765,15 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+            "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+            }
+        },
         "node_modules/util-deprecate": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -12705,7 +12804,6 @@
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -12837,7 +12935,6 @@
             "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -12851,7 +12948,6 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -12959,6 +13055,15 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/jonschlinkert"
+            }
+        },
+        "node_modules/void-elements": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+            "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/volcano-dashboard-app": {
@@ -13296,7 +13401,6 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
             "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },


### PR DESCRIPTION
This PR addresses the LFX Mentorship prerequisite task (Issue #197) and translate dashboard into chinese. 

Logic:
This PR introduces a scalable translation setup using react-i18next. All UI strings were moved into separate translation.json files for each language and components now use useTranslation() for dynamic text rendering. Translations are lazy-loaded with i18next-http-backend, keeping the initial bundle lightweight.<Suspense> handles loading gracefully. This setup also makes future translations straightforward, as it is only needed to add new keys to the JSON files and replace strings with useTranslation() calls.
I've not translated entire dashboard website to keep the PR minimal. Other pages can be translated with same logic as mentioned above.

### Changes
- **Dependencies:** Added `i18next`, `react-i18next`, `i18next-http-backend`, and `i18next-browser-languagedetector`.
- **i18n Initialization:** Configured `frontend/src/i18n.js` with HTTP lazy-loading and wired it into `main.jsx` with a React `Suspense` boundary.
- **Locales:** Added `en` and `zh` translation JSONs containing keys for all Dashboard cards, charts, and buttons in `frontend/public/locales/`.
- **Target Page Components Updated:**
  - `DashboardHeader.jsx`: Added the toggle language button and translated the main page title.
  - `StatCardsContainer.jsx`: Translated card labels ("Total Jobs", "Active Queues", etc.).
  - `JobStatusPieChart.jsx`: Translated jobs status card title, legends, tooltips, and empty states.
  - `QueueResourcesBarChart.jsx`: Translated queue card header, select labels, y-axis labels, and dataset descriptions ("Allocated", "Capacity").

### Testing Done
- Verified that clicking the **"中文"** toggle re-renders all text on the Dashboard page immediately.
- Verified that clicking the **"English"** toggle instantly returns all labels to standard English.
- Verified that the appropriate translation JSONs are correctly lazy-loaded via network calls only when requested.
- Verified that all unit tests continue to pass without issues.

### Screenshots

English
<img width="1898" height="862" alt="image" src="https://github.com/user-attachments/assets/cd788340-e744-49b1-9740-3e7985ae2ee3" />

Chinese
<img width="1897" height="863" alt="image" src="https://github.com/user-attachments/assets/5aca4a8c-bbc3-4554-bbdd-20d21d3eeebb" />
