### PR TITLE
feat: translate queues ui section into simplified chinese

### DIFF
--- a/frontend/src/components/queues/QueuePagination.jsx
+++ b/frontend/src/components/queues/QueuePagination.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Box, Typography, Pagination, Select, MenuItem } from "@mui/material";
+import { queueTranslations } from "./translations";
 
 const QueuePagination = ({
     pagination,
@@ -7,6 +8,8 @@ const QueuePagination = ({
     handleChangeRowsPerPage,
     handleChangePage,
 }) => {
+    const t = queueTranslations.zhCN;
+
     return (
         <Box
             sx={{
@@ -21,9 +24,9 @@ const QueuePagination = ({
                 onChange={handleChangeRowsPerPage}
                 size="small"
             >
-                <MenuItem value={5}>5 per page</MenuItem>
-                <MenuItem value={10}>10 per page</MenuItem>
-                <MenuItem value={20}>20 per page</MenuItem>
+                <MenuItem value={5}>{t.perPage(5)}</MenuItem>
+                <MenuItem value={10}>{t.perPage(10)}</MenuItem>
+                <MenuItem value={20}>{t.perPage(20)}</MenuItem>
             </Select>
             <Box
                 sx={{
@@ -35,7 +38,7 @@ const QueuePagination = ({
                 }}
             >
                 <Typography variant="body2" sx={{ mr: 2 }}>
-                    Total Queues: {totalQueues}
+                    {t.totalQueues}: {totalQueues}
                 </Typography>
                 <Pagination
                     count={Math.ceil(totalQueues / pagination.rowsPerPage)}

--- a/frontend/src/components/queues/QueueTable/QueueTable.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTable.jsx
@@ -12,6 +12,7 @@ import {
 import QueueTableHeader from "./QueueTableHeader";
 import QueueTableRow from "./QueueTableRow";
 import QueueTableDeleteDialog from "./QueueTableDeleteDialog";
+import { queueTranslations } from "../translations";
 
 const QueueTable = ({
     sortedQueues,
@@ -28,6 +29,7 @@ const QueueTable = ({
     onQueueUpdate,
 }) => {
     const theme = useTheme();
+    const t = queueTranslations.zhCN;
 
     const [queues, setQueues] = useState([]);
 
@@ -174,7 +176,7 @@ const QueueTable = ({
                                     colSpan={allocatedFields.length + 2}
                                     align="center"
                                 >
-                                    No queues found.
+                                    {t.noQueuesFound}
                                 </TableCell>
                             </TableRow>
                         ) : (

--- a/frontend/src/components/queues/QueueTable/QueueTableHeader.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTableHeader.jsx
@@ -18,6 +18,7 @@ import {
     FilterList,
     UnfoldMore,
 } from "@mui/icons-material";
+import { queueTranslations } from "../translations";
 
 const QueueTableHeader = ({
     allocatedFields,
@@ -31,6 +32,7 @@ const QueueTableHeader = ({
     setAnchorEl,
 }) => {
     const theme = useTheme();
+    const t = queueTranslations.zhCN;
 
     return (
         <TableHead>
@@ -53,7 +55,7 @@ const QueueTableHeader = ({
                         color="text.primary"
                         sx={{ letterSpacing: "0.02em" }}
                     >
-                        Name
+                        {t.queueName}
                     </Typography>
                 </TableCell>
 
@@ -83,7 +85,7 @@ const QueueTableHeader = ({
                                 color="text.primary"
                                 sx={{ letterSpacing: "0.02em" }}
                             >
-                                {`Allocated ${field}`}
+                                {t.allocatedField(field)}
                             </Typography>
                             <IconButton
                                 size="small"
@@ -135,7 +137,7 @@ const QueueTableHeader = ({
                         color="text.primary"
                         sx={{ letterSpacing: "0.02em" }}
                     >
-                        Creation Time
+                        {t.creationTime}
                     </Typography>
                     <Button
                         size="small"
@@ -176,7 +178,7 @@ const QueueTableHeader = ({
                             },
                         }}
                     >
-                        Sort
+                        {t.sort}
                     </Button>
                 </TableCell>
                 <TableCell
@@ -197,7 +199,7 @@ const QueueTableHeader = ({
                         color="text.primary"
                         sx={{ letterSpacing: "0.02em" }}
                     >
-                        State
+                        {t.state}
                     </Typography>
                     <Button
                         size="small"
@@ -228,7 +230,7 @@ const QueueTableHeader = ({
                             },
                         }}
                     >
-                        Filter: {filters.status}
+                        {t.filter}: {filters.status === "All" ? t.all : filters.status}
                     </Button>
                     <Menu
                         anchorEl={anchorEl.status}
@@ -288,7 +290,7 @@ const QueueTableHeader = ({
                                     }),
                                 }}
                             >
-                                {status}
+                                {status === "All" ? t.all : status}
                             </MenuItem>
                         ))}
                     </Menu>
@@ -312,7 +314,7 @@ const QueueTableHeader = ({
                         color="text.primary"
                         sx={{ letterSpacing: "0.02em" }}
                     >
-                        Actions
+                        {t.actions}
                     </Typography>
                 </TableCell>
             </TableRow>

--- a/frontend/src/components/queues/QueueTable/QueueTableRow.jsx
+++ b/frontend/src/components/queues/QueueTable/QueueTableRow.jsx
@@ -4,6 +4,7 @@ import { Delete } from "@mui/icons-material";
 import { IconButton } from "@mui/material";
 import Edit from "@mui/icons-material/Edit";
 import EditQueueDialog from "./EditQueueDialog";
+import { queueTranslations } from "../translations";
 
 const QueueTableRow = ({
     queue,
@@ -13,6 +14,7 @@ const QueueTableRow = ({
     onQueueUpdate,
 }) => {
     const theme = useTheme();
+    const t = queueTranslations.zhCN;
     const [isEditDialogOpen, setIsEditDialogOpen] = useState(false);
 
     const getStateColor = (status) => {
@@ -105,7 +107,7 @@ const QueueTableRow = ({
 
                 <TableCell sx={{ padding: "16px 24px" }}>
                     <Chip
-                        label={queue.status ? queue.status.state : "Unknown"}
+                        label={queue.status ? queue.status.state : t.unknown}
                         sx={{
                             bgcolor: getStateColor(
                                 queue.status ? queue.status.state : "Unknown",

--- a/frontend/src/components/queues/QueueYamlDialog.jsx
+++ b/frontend/src/components/queues/QueueYamlDialog.jsx
@@ -7,6 +7,7 @@ import {
     Box,
     Button,
 } from "@mui/material";
+import { queueTranslations } from "./translations";
 
 const QueueYamlDialog = ({
     openDialog,
@@ -14,6 +15,8 @@ const QueueYamlDialog = ({
     selectedQueueName,
     selectedQueueYaml,
 }) => {
+    const t = queueTranslations.zhCN;
+
     return (
         <Dialog
             open={openDialog}
@@ -30,7 +33,7 @@ const QueueYamlDialog = ({
                 },
             }}
         >
-            <DialogTitle>Queue YAML - {selectedQueueName}</DialogTitle>
+            <DialogTitle>{t.queueYamlTitle} - {selectedQueueName}</DialogTitle>
             <DialogContent>
                 <Box
                     sx={{
@@ -79,7 +82,7 @@ const QueueYamlDialog = ({
                             },
                         }}
                     >
-                        Close
+                        {t.close}
                     </Button>
                 </Box>
             </DialogActions>

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -4,11 +4,13 @@ import axios from "axios";
 import { parseCPU, parseMemoryToMi } from "../utils";
 import SearchBar from "../Searchbar";
 import QueueTable from "./QueueTable/QueueTable";
+import { queueTranslations } from "./translations";
 import QueuePagination from "./QueuePagination";
 import QueueYamlDialog from "./QueueYamlDialog";
 import TitleComponent from "../Titlecomponent";
 
 const Queues = () => {
+    const t = queueTranslations.zhCN;
     const [queues, setQueues] = useState([]);
     const [loading, setLoading] = useState(true);
     const [error, setError] = useState(null);
@@ -47,7 +49,7 @@ const Queues = () => {
             setQueues(data.items || []);
             setTotalQueues(data.totalCount || 0);
         } catch (err) {
-            setError("Failed to fetch queues: " + err.message);
+            setError(`${t.fetchQueuesError}: ${err.message}`);
             setQueues([]);
         } finally {
             setLoading(false);
@@ -70,10 +72,12 @@ const Queues = () => {
                 return;
             }
 
-            alert("Queue created successfully!");
+            alert(t.queueCreatedSuccess);
         } catch (err) {
             alert(
-                "Network error: " + (err?.response?.data?.error || err.message),
+                `${t.networkError}: ${
+                    err?.response?.data?.error || err.message
+                }`,
             );
         } finally {
             setLoading(false);
@@ -122,7 +126,7 @@ const Queues = () => {
             setOpenDialog(true);
         } catch (err) {
             console.error("Failed to fetch queue YAML:", err);
-            setError("Failed to fetch queue YAML: " + err.message);
+            setError(`${t.fetchQueueYamlError}: ${err.message}`);
         } finally {
             setLoading(false);
         }
@@ -233,7 +237,7 @@ const Queues = () => {
                     <Typography variant="body1">{error}</Typography>
                 </Box>
             )}
-            <TitleComponent text="Volcano Queues Status" />
+            <TitleComponent text={t.title} />
             <Box>
                 <SearchBar
                     searchText={searchText}
@@ -242,13 +246,13 @@ const Queues = () => {
                     handleRefresh={handleRefresh}
                     fetchData={fetchQueues}
                     isRefreshing={loading}
-                    placeholder="Search queues..."
-                    refreshLabel="Refresh Queues"
-                    createlabel="Create Queue"
+                    placeholder={t.searchPlaceholder}
+                    refreshLabel={t.refreshQueues}
+                    createlabel={t.createQueue}
                     onCreateClick={handleCreateQueue}
-                    dialogTitle="Create a Queue"
-                    dialogResourceNameLabel="Queue Name"
-                    dialogResourceType="Queue"
+                    dialogTitle={t.createQueueDialog}
+                    dialogResourceNameLabel={t.queueName}
+                    dialogResourceType={t.queue}
                 />
             </Box>
             <QueueTable

--- a/frontend/src/components/queues/translations.jsx
+++ b/frontend/src/components/queues/translations.jsx
@@ -1,0 +1,39 @@
+export const queueTranslations = {
+    zhCN: {
+        title: "Volcano 队列状态",
+
+        searchPlaceholder: "搜索队列...",
+        refreshQueues: "刷新队列",
+        createQueue: "创建队列",
+        createQueueDialog: "创建队列",
+
+        queueName: "队列名称",
+        queue: "队列",
+        noQueuesFound: "未找到队列",
+
+        totalQueues: "队列总数",
+
+        perPage: (count) => `每页 ${count} 条`,
+
+        allocatedField: (field) => `已分配 ${field}`,
+
+        creationTime: "创建时间",
+        sort: "排序",
+
+        state: "状态",
+        filter: "筛选",
+        all: "全部",
+
+        actions: "操作",
+
+        queueYamlTitle: "队列 YAML",
+        close: "关闭",
+
+        unknown: "未知",
+
+        fetchQueuesError: "获取队列失败",
+        fetchQueueYamlError: "获取队列 YAML 失败",
+        networkError: "网络错误",
+        queueCreatedSuccess: "队列创建成功！",
+    },
+};


### PR DESCRIPTION
## Summary

This PR translates the primary Queues page UI in Volcano Dashboard into Simplified Chinese.

The update includes:

* queue page title
* search and action labels
* table headers
* pagination labels
* filter labels
* empty state messaging
* YAML dialog labels
* user-facing alerts and errors

## Implementation Notes

To keep the contribution incremental and easy to review, the translation logic is scoped locally to the `queues` feature module.

A lightweight translation dictionary was added under:

```plaintext
frontend/src/components/queues/
```

and used only by queue-related components without introducing broader application-wide i18n infrastructure or additional dependencies.

This keeps the change feature-scoped, low-risk, and easy to extend incrementally in future contributions.

## Notes

This PR focuses on presentation-layer queue UI translation only. Kubernetes resource names, raw YAML content, and backend queue state values remain unchanged.


## Screenshots

### Main Queues Page

<img width="1919" height="910" alt="image" src="https://github.com/user-attachments/assets/1815503a-d993-48d7-91a0-b2f2dc7b7743" />

### Queue YAML Inspection Dialog

<img width="1919" height="919" alt="image" src="https://github.com/user-attachments/assets/53d0d4af-17bf-4dd4-8fc7-8270c3765ea4" />
