### PR TITLE
fix: add debounce to pods and queues search

### DIFF
--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -7,6 +7,7 @@ import { fetchAllNamespaces } from "../utils";
 import PodsTable from "./PodsTable/PodsTable";
 import PodsPagination from "./PodsPagination";
 import PodDetailsDialog from "./PodDetailsDialog";
+import { useDebouncedValue } from "../../hooks/useDebouncedValue";
 
 const Pods = () => {
     const [pods, setPods] = useState([]);
@@ -21,6 +22,7 @@ const Pods = () => {
     const [selectedPodYaml, setSelectedPodYaml] = useState("");
     const [openDialog, setOpenDialog] = useState(false);
     const [searchText, setSearchText] = useState("");
+    const debouncedSearchText = useDebouncedValue(searchText, 200);
     const theme = useTheme();
     const [selectedPodName, setSelectedPodName] = useState("");
     const [pagination, setPagination] = useState({
@@ -37,7 +39,7 @@ const Pods = () => {
         try {
             const response = await axios.get(`/api/pods`, {
                 params: {
-                    search: searchText,
+                    search: debouncedSearchText,
                     namespace: filters.namespace,
                     status: filters.status,
                 },
@@ -56,7 +58,7 @@ const Pods = () => {
         } finally {
             setLoading(false);
         }
-    }, [searchText, filters]);
+    }, [debouncedSearchText, filters]);
 
     useEffect(() => {
         fetchPods();
@@ -77,14 +79,12 @@ const Pods = () => {
     const handleClearSearch = () => {
         setSearchText("");
         setPagination((prev) => ({ ...prev, page: 1 }));
-        fetchPods();
     };
 
     const handleRefresh = useCallback(() => {
         setPagination((prev) => ({ ...prev, page: 1 }));
         setSearchText("");
-        fetchPods();
-    }, [fetchPods]);
+    }, []);
 
     const fetchData = async () => {
         try {

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -83,8 +83,13 @@ const Pods = () => {
 
     const handleRefresh = useCallback(() => {
         setPagination((prev) => ({ ...prev, page: 1 }));
-        setSearchText("");
-    }, []);
+    
+        if (searchText === "") {
+            fetchPods();
+        } else {
+            setSearchText("");
+        }
+    }, [searchText, fetchPods]);
 
     const fetchData = async () => {
         try {

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -25,7 +25,7 @@ const Queues = () => {
         field: null,
         direction: "asc",
     });
-    const debouncedSearchText = useDebouncedValue(searchText, 200)
+    const debouncedSearchText = useDebouncedValue(searchText, 200);
 
     // 🟢 1. Fetch all queues
     const fetchQueues = useCallback(async () => {

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -7,6 +7,7 @@ import QueueTable from "./QueueTable/QueueTable";
 import QueuePagination from "./QueuePagination";
 import QueueYamlDialog from "./QueueYamlDialog";
 import TitleComponent from "../Titlecomponent";
+import {useDebouncedValue} from "../../hooks/useDebouncedValue";
 
 const Queues = () => {
     const [queues, setQueues] = useState([]);
@@ -24,6 +25,7 @@ const Queues = () => {
         field: null,
         direction: "asc",
     });
+    const debouncedSearchText = useDebouncedValue(searchText, 200)
 
     // 🟢 1. Fetch all queues
     const fetchQueues = useCallback(async () => {
@@ -34,7 +36,7 @@ const Queues = () => {
                 params: {
                     page: pagination.page,
                     limit: pagination.rowsPerPage,
-                    search: searchText,
+                    search: debouncedSearchText,
                     state: filters.status,
                 },
             });
@@ -52,7 +54,7 @@ const Queues = () => {
         } finally {
             setLoading(false);
         }
-    }, [pagination, searchText, filters]);
+    }, [pagination, debouncedSearchText, filters]);
 
     useEffect(() => {
         fetchQueues();
@@ -82,7 +84,7 @@ const Queues = () => {
 
     const handleSearch = useCallback((event) => {
         setSearchText(event.target.value);
-        setPagination((prev) => ({ ...prev, page: 1 }));
+        setPagination((prev) => prev.page === 1 ? prev : ({ ...prev, page: 1 }));
     }, []);
 
     const handleClearSearch = useCallback(() => {
@@ -93,8 +95,7 @@ const Queues = () => {
     const handleRefresh = useCallback(() => {
         setPagination((prev) => ({ ...prev, page: 1 }));
         setSearchText("");
-        fetchQueues();
-    }, [fetchQueues]);
+    }, []);
 
     const handleQueueClick = useCallback(async (queue) => {
         try {

--- a/frontend/src/hooks/useDebouncedValue.js
+++ b/frontend/src/hooks/useDebouncedValue.js
@@ -1,0 +1,15 @@
+import {useEffect, useState} from "react"
+
+export const useDebouncedValue = (value, delay = 200) =>{
+    const [debouncedValue, setdebouncedValue] = useState(value)
+
+    useEffect(()=>{
+        const timeoutId = setTimeout(()=>{
+            setdebouncedValue(value)
+        },delay)
+
+        return ()=> clearTimeout(timeoutId);
+    },[value,delay]);
+
+    return debouncedValue;
+};

--- a/frontend/src/hooks/useDebouncedValue.js
+++ b/frontend/src/hooks/useDebouncedValue.js
@@ -1,11 +1,11 @@
 import {useEffect, useState} from "react"
 
 export const useDebouncedValue = (value, delay = 200) =>{
-    const [debouncedValue, setdebouncedValue] = useState(value)
+    const [debouncedValue, setDebouncedValue] = useState(value)
 
     useEffect(()=>{
         const timeoutId = setTimeout(()=>{
-            setdebouncedValue(value)
+            setDebouncedValue(value)
         },delay)
 
         return ()=> clearTimeout(timeoutId);


### PR DESCRIPTION
## Summary
#274 

Adds debounced search for Pods and Queues to avoid sending backend requests on every keystroke.

## Changes

Added reusable useDebouncedValue hook.
Updated Pods search to use debounced search text.
Updated Queues search to use debounced search text.
Preserved existing pagination and refresh behavior.