### PR TITLE
fix: replace hardcoded dashboard table search placeholder

### DIFF
--- a/apps/web/src/components/(dashboard)/data-table.tsx
+++ b/apps/web/src/components/(dashboard)/data-table.tsx
@@ -36,6 +36,7 @@ interface DataTableProps<TData, TValue> {
   data: TData[]
   onRowClick?: (row: TData) => void
   disablePagination?: boolean
+  searchPlaceholder?: string
 }
 
 export function DataTable<TData, TValue>({
@@ -43,6 +44,7 @@ export function DataTable<TData, TValue>({
   data,
   onRowClick,
   disablePagination = false,
+  searchPlaceholder = "Filter..."
 }: DataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([])
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
@@ -72,7 +74,7 @@ export function DataTable<TData, TValue>({
     <div className="w-full">
       <div className="flex items-center py-4">
         <Input
-          placeholder="Filter jobs..."
+          placeholder={searchPlaceholder}
           value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
             table.getColumn("name")?.setFilterValue(event.target.value)

--- a/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
+++ b/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
@@ -304,6 +304,7 @@ export default function JobsManagement() {
               data={jobs || []}
               onRowClick={handleJobClick}
               disablePagination={true}
+              searchPlaceholder="Filter Jobs ..."
             />
           </div>
 

--- a/apps/web/src/components/(dashboard)/pods/pod-management.tsx
+++ b/apps/web/src/components/(dashboard)/pods/pod-management.tsx
@@ -296,6 +296,7 @@ export default function PodManagement() {
                             data={pods || []}
                             onRowClick={handlePodClick}
                             disablePagination={true}
+                            searchPlaceholder="Filter Pods ..."
                         />
                     </div>
 

--- a/apps/web/src/components/(dashboard)/queues/queue-management.tsx
+++ b/apps/web/src/components/(dashboard)/queues/queue-management.tsx
@@ -290,6 +290,7 @@ export default function QueueManagement() {
                             data={queues || []}
                             onRowClick={handleQueueClick}
                             disablePagination={true}
+                            searchPlaceholder="Filter Queues ..."
                         />
                     </div>
 


### PR DESCRIPTION
## Summary
#277 
- Added a `searchPlaceholder` prop to the shared dashboard `DataTable` component.
- Replaced the hardcoded `Filter jobs...` placeholder with table-specific placeholder text.
- Updated Jobs, Pods, and Queues tables so the search input matches the resource being filtered.

## ScreenShots 

## Before 
<img width="411" height="373" alt="image" src="https://github.com/user-attachments/assets/483439b4-ee39-46d2-8acb-119b8b988bb3" />

<img width="400" height="363" alt="image" src="https://github.com/user-attachments/assets/b989afcb-8d28-492e-af92-60e25a9a2299" />

## After 
<img width="431" height="348" alt="image" src="https://github.com/user-attachments/assets/a9afd731-dbfd-4c5e-b0a2-d261fc57793d" />
<img width="421" height="340" alt="image" src="https://github.com/user-attachments/assets/22181f05-411b-46a4-8d89-dbb08b881b2d" />




## Testing
- npm run build
- npm run lint
- npx tsc -p apps/web/tsconfig.json --noEmit