### PR TITLE
Instead of relying on the reactive state query parameter with .refetch(), fetch the YAML dynamically

### DIFF
--- a/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
+++ b/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
@@ -62,19 +62,7 @@ export default function JobsManagement() {
     }
   )
 
-  const jobYamlQuery = trpc.jobsRouter.getJobYaml.useQuery(
-    {
-      namespace: selectedJob?.namespace || "",
-      name: selectedJob?.name || "",
-    },
-    {
-      enabled: false,
-      onError: (err) => {
-        console.error("Error fetching job YAML:", err);
-        setError(`Job YAML API error: ${err.message}`);
-      },
-    },
-  );
+
 
   const availableNamespaces = jobs ?
     Array.from(new Set(jobs.map(job => job.namespace).filter(Boolean))).sort()
@@ -210,15 +198,17 @@ export default function JobsManagement() {
     setError(null);
 
     try {
-      const response = await jobYamlQuery.refetch();
-      const yaml = response.data || job.yaml || "";
-      setSelectedJob({ ...job, yaml });
+      const yaml = await utils.jobsRouter.getJobYaml.fetch({
+        namespace: job.namespace,
+        name: job.name
+      });
+      setSelectedJob({ ...job, yaml: yaml || "" });
       setShowJobDetails(true);
     } catch (err) {
       setError("Failed to fetch job YAML");
       console.error(err)
     }
-  }, [jobYamlQuery]);
+  }, [utils]);
 
   const handleJobCreate = () => {
     setShowCreateJobModal(true)

--- a/apps/web/src/components/(dashboard)/pods/pod-management.tsx
+++ b/apps/web/src/components/(dashboard)/pods/pod-management.tsx
@@ -67,19 +67,7 @@ export default function PodManagement() {
     )
 
 
-    const podYamlQuery = trpc.podRouter.getPodYaml.useQuery(
-        {
-            namespace: selectedPod?.namespace || "",
-            name: selectedPod?.name || ""
-        },
-        {
-            enabled: false,
-            onError: (err) => {
-                console.error("Error fetching pod YAML:", err);
-                setError(`Pod YAML API error: ${err.message}`);
-            },
-        },
-    );
+
 
     const availableNamespaces = pods ?
         Array.from(new Set(pods.map(pod => pod.namespace).filter(Boolean))).sort()
@@ -204,15 +192,17 @@ export default function PodManagement() {
         setError(null);
 
         try {
-            const response = await podYamlQuery.refetch();
-            const yaml = response.data || pod.yaml || "";
-            setSelectedPod({ ...pod, yaml });
+            const yaml = await utils.podRouter.getPodYaml.fetch({
+                namespace: pod.namespace,
+                name: pod.name
+            });
+            setSelectedPod({ ...pod, yaml: yaml || "" });
             setShowPodDetails(true);
         } catch (err) {
             setError("Failed to fetch pod YAML");
             console.error(err)
         }
-    }, [podYamlQuery])
+    }, [utils])
 
     const handlePodCreate = () => {
         setShowCreatePodModal(true)

--- a/apps/web/src/components/(dashboard)/queues/queue-management.tsx
+++ b/apps/web/src/components/(dashboard)/queues/queue-management.tsx
@@ -151,16 +151,7 @@ export default function QueueManagement() {
         onDelete: handleDelete
     })
 
-    const queueYamlQuery = trpc.queueRouter.getQueueYaml.useQuery(
-        { name: selectedQueue?.name || "" },
-        {
-            enabled: false,
-            onError: (err) => {
-                console.error("Error fetching queue YAML:", err);
-                setError(`Queue YAML API error: ${err.message}`);
-            },
-        },
-    );
+
 
     useEffect(() => {
         if (queuesQuery.data) {
@@ -202,15 +193,16 @@ export default function QueueManagement() {
         setError(null);
 
         try {
-            const response = await queueYamlQuery.refetch();
-            const yaml = response.data || queue.yaml || "";
-            setSelectedQueue({ ...queue, yaml });
+            const yaml = await utils.queueRouter.getQueueYaml.fetch({
+                name: queue.name
+            });
+            setSelectedQueue({ ...queue, yaml: yaml || "" });
             setShowQueueDetails(true);
         } catch (err) {
             setError("Failed to fetch queue YAML");
             console.error(err)
         }
-    }, [queueYamlQuery])
+    }, [utils])
 
     const handleCreateQueue = () => {
         setShowCreateQueueModal(true)

--- a/package-lock.json
+++ b/package-lock.json
@@ -2631,7 +2631,6 @@
       "version": "18.3.18",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2641,7 +2640,6 @@
       "version": "18.3.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2678,7 +2676,6 @@
       "version": "8.23.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.23.0",
         "@typescript-eslint/types": "8.23.0",
@@ -2853,7 +2850,6 @@
       "version": "8.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3803,7 +3799,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3960,7 +3955,6 @@
       "version": "2.31.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5681,7 +5675,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -5840,7 +5833,6 @@
     "apps/web/node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5851,7 +5843,6 @@
     "apps/web/node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6635,7 +6626,6 @@
     "apps/web/node_modules/tailwindcss": {
       "version": "3.4.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6845,7 +6835,6 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7178,17 +7167,6 @@
         }
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.7.0",
       "license": "MIT",
@@ -7419,6 +7397,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -7433,6 +7412,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -7441,28 +7421,6 @@
       },
       "optionalDependencies": {
         "@img/sharp-libvips-linux-x64": "1.1.0"
-      }
-    },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
     "node_modules/@jsep-plugin/assignment": {
@@ -7515,7 +7473,8 @@
     },
     "node_modules/@next/env": {
       "version": "15.3.5",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.3.5",
@@ -7537,6 +7496,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7553,6 +7513,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7569,6 +7530,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7585,6 +7547,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7599,6 +7562,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7615,6 +7579,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7631,6 +7596,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7647,6 +7613,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7663,6 +7630,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7710,11 +7678,13 @@
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -7737,7 +7707,6 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@trpc/server": "10.45.2"
       }
@@ -7749,15 +7718,13 @@
       "funding": [
         "https://trpc.io/sponsor"
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ts-rest/core": {
       "version": "3.52.1",
       "resolved": "https://registry.npmjs.org/@ts-rest/core/-/core-3.52.1.tgz",
       "integrity": "sha512-tAjz7Kxq/grJodcTA1Anop4AVRDlD40fkksEV5Mmal88VoZeRKAG8oMHsDwdwPZz+B/zgnz0q2sF+cm5M7Bc7g==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/node": "^18.18.7 || >=20.8.4",
         "zod": "^3.22.3"
@@ -7770,26 +7737,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -7810,7 +7757,6 @@
     "node_modules/@types/node": {
       "version": "22.16.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7884,7 +7830,6 @@
       "version": "8.35.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.1",
         "@typescript-eslint/types": "8.35.1",
@@ -8108,7 +8053,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8121,17 +8065,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -8169,11 +8102,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -8434,6 +8362,7 @@
     },
     "node_modules/busboy": {
       "version": "1.6.0",
+      "peer": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -8515,7 +8444,8 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -8533,7 +8463,8 @@
     },
     "node_modules/client-only": {
       "version": "0.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/co-body": {
       "version": "6.2.0",
@@ -8555,6 +8486,7 @@
       "version": "4.2.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -8581,6 +8513,7 @@
       "version": "1.9.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -8634,11 +8567,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8800,16 +8728,9 @@
       "version": "2.0.4",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -9024,7 +8945,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9547,7 +9467,8 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -9786,7 +9707,8 @@
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -10193,7 +10115,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -10292,11 +10213,6 @@
       "bin": {
         "loose-envify": "cli.js"
       }
-    },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -10412,6 +10328,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -10435,6 +10352,7 @@
     "node_modules/next": {
       "version": "15.3.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.3.5",
         "@swc/counter": "0.1.3",
@@ -10523,6 +10441,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10539,6 +10458,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10555,6 +10475,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10571,6 +10492,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10587,6 +10509,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10603,6 +10526,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10619,6 +10543,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10909,7 +10834,8 @@
     },
     "node_modules/picocolors": {
       "version": "1.0.1",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -10947,6 +10873,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -10961,7 +10888,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -11287,7 +11213,8 @@
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.6.2",
@@ -11354,6 +11281,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.4",
@@ -11393,6 +11321,7 @@
       "version": "7.7.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11485,6 +11414,7 @@
       "version": "0.2.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -11530,6 +11460,7 @@
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11572,6 +11503,7 @@
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -11690,6 +11622,7 @@
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -11841,13 +11774,13 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/turbo": {
       "version": "2.5.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "turbo": "bin/turbo"
       },
@@ -12037,9 +11970,8 @@
     },
     "node_modules/typescript": {
       "version": "5.8.2",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12139,11 +12071,6 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
-    },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/web": {
       "resolved": "apps/web",
@@ -12277,7 +12204,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12292,14 +12218,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -12317,7 +12235,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.72.tgz",
       "integrity": "sha512-Cl+fe4dNL4XumOBNBsr0lHfA80PQiZXHI4xEMTEr8gt6aGz92t3lBA32e71j9+JeF/VAYvdfBnuwJs+BMx/BrA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12377,7 +12294,8 @@
       "version": "14.2.30",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.30.tgz",
       "integrity": "sha512-KBiBKrDY6kxTQWGzKjQB7QirL3PiiOkV7KW98leHFjtVRKtft76Ra5qSA/SL75xT44dp6hOcqiiJ6iievLOYug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "packages/trpc/node_modules/@next/swc-linux-x64-gnu": {
       "version": "14.2.30",
@@ -12391,6 +12309,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -12400,6 +12319,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
       "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -12410,7 +12330,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.40.0.tgz",
       "integrity": "sha512-kt1G/wETT/Ad79cac5zJ8tyaMOm4rgyeomW5yDxgOO9qEhOwufgw9kgPpp+T9U0M0lL7EMoc6YXgv4gYhXu9tg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "4.40.0",
         "use-sync-external-store": "^1.2.0"
@@ -12459,7 +12378,6 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@tanstack/react-query": "^4.18.0",
         "@trpc/client": "10.45.2",
@@ -12540,7 +12458,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12567,6 +12484,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -12576,6 +12494,7 @@
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
       "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },


### PR DESCRIPTION
Closes #280 

### Brief Solution
Instead of relying on the reactive state query parameter with `.refetch()`, fetch the YAML dynamically on demand using the tRPC context/client cache or by calling `fetch` directly with the clicked row's details in the handler:
```typescript
const handleJobClick = useCallback(async (job: JobStatus) => {
  setError(null);
  try {
    const yaml = await utils.jobsRouter.getJobYaml.fetch({
      namespace: job.namespace,
      name: job.name
    });
    setSelectedJob({ ...job, yaml: yaml || "" });
    setShowJobDetails(true);
  } catch (err) {
    setError("Failed to fetch job YAML");
  }
}, [utils]);
```
### Why it happens
1. When you click on a job or pod, the website is supposed to tell the server: *"Give me the details for Job X."*
2. But because of how the code is written, it triggers the request to the server **before** it updates the active selection in its memory.
3. So, the website sends a request to the server asking for details about `""` (nothing / empty text).
4. The server gets confused, returns an error, and the details window either fails to open or shows an error.
### Simple Solution
Update the code so it first remembers exactly which job you clicked, and then immediately asks the server for that specific job's details instead of asking for "whatever is currently selected."

@de6p 
/review