### PR TITLE
fix: escape YAML keys and values in dialogs to prevent Stored XSS (#276)

### DIFF
--- a/frontend/src/components/jobs/Jobs.jsx
+++ b/frontend/src/components/jobs/Jobs.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import axios from "axios";
+import { escape } from "lodash";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces, fetchAllQueues } from "../utils";
 import JobTable from "./JobTable/JobTable";
@@ -104,9 +105,9 @@ const Jobs = () => {
                     if (keyMatch) {
                         const [, indent, key] = keyMatch;
                         const value = line.slice(keyMatch[0].length);
-                        return `${indent}<span class="yaml-key">${key}</span>:${value}`;
+                        return `${indent}<span class="yaml-key">${escape(key)}</span>:${escape(value)}`;
                     }
-                    return line;
+                    return escape(line);
                 })
                 .join("\n");
 

--- a/frontend/src/components/pods/Pods.jsx
+++ b/frontend/src/components/pods/Pods.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import axios from "axios";
+import { escape } from "lodash";
 import SearchBar from "../Searchbar";
 import TitleComponent from "../Titlecomponent";
 import { fetchAllNamespaces } from "../utils";
@@ -140,9 +141,9 @@ const Pods = () => {
                     if (keyMatch) {
                         const [, indent, key] = keyMatch;
                         const value = line.slice(keyMatch[0].length);
-                        return `${indent}<span class="yaml-key">${key}</span>:${value}`;
+                        return `${indent}<span class="yaml-key">${escape(key)}</span>:${escape(value)}`;
                     }
-                    return line;
+                    return escape(line);
                 })
                 .join("\n");
 

--- a/frontend/src/components/queues/Queues.jsx
+++ b/frontend/src/components/queues/Queues.jsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { Box, Typography } from "@mui/material";
 import axios from "axios";
+import { escape } from "lodash";
 import { parseCPU, parseMemoryToMi } from "../utils";
 import SearchBar from "../Searchbar";
 import QueueTable from "./QueueTable/QueueTable";
@@ -111,9 +112,9 @@ const Queues = () => {
                     if (keyMatch) {
                         const [, indent, key] = keyMatch;
                         const value = line.slice(keyMatch[0].length);
-                        return `${indent}<span class="yaml-key">${key}</span>:${value}`;
+                        return `${indent}<span class="yaml-key">${escape(key)}</span>:${escape(value)}`;
                     }
-                    return line;
+                    return escape(line);
                 })
                 .join("\n");
 


### PR DESCRIPTION
This PR fixes the stored XSS vulnerability reported in #276.

### What was the problem?
When viewing the YAML definition for Jobs, Pods, or Queues, the frontend splits the raw YAML lines and highlights the keys by wrapping them in a `span` tag. It then renders the whole formatted block using `dangerouslySetInnerHTML`.

The issue is that the keys and values weren't being HTML-escaped. If someone created a resource with malicious HTML or javascript in its annotations, labels, or env variables, that script would execute in the user's browser.

### How this PR fixes it:
- Imported `escape` from `lodash`.
- Wrapped the YAML keys, values, and unparsed lines in `escape()` before generating the markup inside `Jobs.jsx`, `Pods.jsx`, and `Queues.jsx`.
- This mirrors the escaping pattern that was already correctly implemented in `PodGroups.jsx`.

Closes #276

### Testing:
- Verified that HTML/JS payloads (like `<script>`) are now safely rendered as plain text instead of executing.
- Ran `npm run lint` and `npm run format` locally to ensure everything is clean.