### PR TITLE
fix: add debounced to podgroup search

### DIFF
--- a/apps/web/src/components/(dashboard)/podgroups/podgroup-management.tsx
+++ b/apps/web/src/components/(dashboard)/podgroups/podgroup-management.tsx
@@ -45,6 +45,7 @@ export default function PodGroupManagement() {
     const [selectedPodGroup, setSelectedPodGroup] = useState<PodGroupStatus | null>(null)
     const [showPodGroupDetails, setShowPodGroupDetails] = useState(false)
     const [searchTerm, setSearchTerm] = useState("")
+    const [debouncedSearchTerm, setDebouncedSearchTerm] = useState("")
     const [namespaceFilter, setNamespaceFilter] = useState("")
     const [statusFilter, setStatusFilter] = useState("")
 
@@ -53,10 +54,19 @@ export default function PodGroupManagement() {
         pageSize: 10,
     })
 
+    useEffect(() => {
+        const timer = window.setTimeout(() => {
+            setDebouncedSearchTerm(searchTerm)
+            setPagination((prev) => ({ ...prev, page: 1 }))
+        }, 200)
+
+        return () => window.clearTimeout(timer)
+    }, [searchTerm])
+
     const podGroupsQuery = trpc.podgroupsRouter.getPodGroups.useQuery(
         {
             namespace: namespaceFilter || "",
-            search: searchTerm || "",
+            search: debouncedSearchTerm || "",
             status: statusFilter || "",
             page: pagination.page,
             pageSize: pagination.pageSize,
@@ -131,6 +141,12 @@ export default function PodGroupManagement() {
         setError(null)
 
         try {
+            if (searchTerm !== debouncedSearchTerm) {
+                setDebouncedSearchTerm(searchTerm)
+                setPagination((prev) => ({ ...prev, page: 1 }))
+                return
+            }
+
             await podGroupsQuery.refetch();
         } catch (err) {
             setError("Failed to refresh podgroups")
@@ -138,7 +154,7 @@ export default function PodGroupManagement() {
         } finally {
             setLoading(false)
         }
-    }, [podGroupsQuery])
+    }, [podGroupsQuery, searchTerm, debouncedSearchTerm])
 
     const handlePodGroupClick = useCallback(async (podGroup: PodGroupStatus) => {
         setError(null);
@@ -213,7 +229,6 @@ export default function PodGroupManagement() {
                         value={searchTerm}
                         onChange={(e) => {
                             setSearchTerm(e.target.value);
-                            setPagination({ ...pagination, page: 1 });
                         }}
                         className="pl-10"
                     />
@@ -224,7 +239,8 @@ export default function PodGroupManagement() {
                             className="absolute right-1 top-1/2 transform -translate-y-1/2 h-6 w-6 p-0"
                             onClick={() => {
                                 setSearchTerm("");
-                                setPagination({ ...pagination, page: 1 });
+                                setDebouncedSearchTerm("");
+                                setPagination((prev) => ({ ...prev, page: 1 }));
                             }}
                         >
                             <X className="h-4 w-4" />
@@ -358,4 +374,3 @@ export default function PodGroupManagement() {
         </div>
     )
 }
-


### PR DESCRIPTION
## Summary
- Added debounce handling to the PodGroup search input to avoid updating the query on every keystroke.
- Introduced a debounced search value and updated the PodGroup tRPC query to use it instead of the raw input value.
- Reset pagination to the first page when a new debounced search is applied, so filtered results start from the beginning.
- Kept the Refresh action responsive by applying any pending search input before refreshing.


## Testing
- npm run lint
- npx tsc -p apps/web/tsconfig.json --noEmit