### PR TITLE
security: Restrict CORS Wildcard Origin with Configurable Host Filter #284

### DIFF
--- a/packages/trpc/server/app.ts
+++ b/packages/trpc/server/app.ts
@@ -6,37 +6,40 @@ import { configs } from "./utils/configs";
 import { k8sApi } from "./utils/k8s";
 
 const app = express();
-app.use(cors({ origin: "*" }));
+app.use(
+  cors({
+    origin: configs.AllowedOrigins,
+    credentials: true,
+  }),
+);
 
 app.use(
-    "/api",
-    trpcExpress.createExpressMiddleware({
-        router: appRouter,
-        createContext: () => ({ session: null }),
-    }),
+  "/api",
+  trpcExpress.createExpressMiddleware({
+    router: appRouter,
+    createContext: () => ({ session: null }),
+  }),
 );
 
 const verifyVolcanoSetup = async () => {
-    try {
-        await k8sApi.listClusterCustomObject({
-            group: "batch.volcano.sh",
-            version: "v1alpha1",
-            plural: "jobs",
-        });
-        return true;
-    } catch (error) {
-        console.error("Volcano verification failed:", error);
-        return false;
-    }
+  try {
+    await k8sApi.listClusterCustomObject({
+      group: "batch.volcano.sh",
+      version: "v1alpha1",
+      plural: "jobs",
+    });
+    return true;
+  } catch (error) {
+    console.error("Volcano verification failed:", error);
+    return false;
+  }
 };
 
 export const server = app.listen(configs.Port, async () => {
-    const volcanoReady = await verifyVolcanoSetup();
-    if (volcanoReady) {
-        console.log(
-            `Server running on port ${configs.Port} with Volcano support`,
-        );
-    } else {
-        console.error("Server started but Volcano support is not available");
-    }
+  const volcanoReady = await verifyVolcanoSetup();
+  if (volcanoReady) {
+    console.log(`Server running on port ${configs.Port} with Volcano support`);
+  } else {
+    console.error("Server started but Volcano support is not available");
+  }
 });

--- a/packages/trpc/server/utils/configs.ts
+++ b/packages/trpc/server/utils/configs.ts
@@ -1,13 +1,19 @@
 import { config as dotenvConfig } from "dotenv";
 
 export interface Configs {
-    Port: number;
-    Env: string;
+  Port: number;
+  Env: string;
+  AllowedOrigins: string[];
 }
 
 dotenvConfig({ path: "secrets.env" });
 
 export const configs: Configs = {
-    Port: parseInt(process.env.PORT || "3001"),
-    Env: process.env.NODE_ENV || "development",
+  Port: parseInt(process.env.PORT || "3001"),
+  Env: process.env.NODE_ENV || "development",
+  AllowedOrigins: process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(",")
+        .map((o) => o.trim())
+        .filter(Boolean)
+    : ["http://localhost:3000", "http://localhost:5173"],
 };


### PR DESCRIPTION
### What this PR does 🚀
Hey folks! This PR fixes a security issue where our backend was allowing any origin (`*`) to access the dashboard API. This permissive configuration could have exposed us to Cross-Site Request Forgery (CSRF) attacks, especially since we work with sensitive Kubernetes data.

### How it was fixed 🛠️
I updated the CORS initialization to use a safe, configurable approach:
- We now check for an `ALLOWED_ORIGINS` environment variable in `configs.ts`.
- If no environment variable is provided, it safely defaults to our standard local development origins (`http://localhost:3000` and `http://localhost:5173`).
- I also enabled `credentials: true` to ensure standard authenticated requests work seamlessly across allowed domains.

### Related Issue 🔗
Fixes #284 

### Testing Done ✅
- [x] Verified that API requests from unauthorized domains are correctly rejected by CORS.
- [x] Verified that the dashboard still functions perfectly on `localhost` without any changes needed on the frontend.
- [x] Ran Prettier to ensure the formatting matches our codebase perfectly.