### PR TITLE
fix: correct badge hover colors and completed job status badge colors

### DIFF
--- a/apps/web/src/components/(dashboard)/jobs/columns.tsx
+++ b/apps/web/src/components/(dashboard)/jobs/columns.tsx
@@ -205,12 +205,12 @@ export const createColumns = ({
           <Badge
             className={
               status === "completed"
-                ? "bg-green-100 text-green-800"
+                ? "bg-green-100 text-green-800 hover:bg-green-100/60"
                 : status === "running"
-                  ? "bg-blue-100 text-blue-800"
+                  ? "bg-blue-100 text-blue-800 hover:bg-blue-100/60"
                   : status === "pending"
-                    ? "bg-yellow-100 text-yellow-800"
-                    : "bg-red-100 text-red-800"
+                    ? "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
+                    : "bg-red-100 text-red-800 hover:bg-red-100/60"
             }
           >
             {status}

--- a/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
+++ b/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
@@ -172,7 +172,7 @@ export default function JobsManagement() {
         namespace: job.metadata?.namespace || '',
         queue: job.spec?.queue || '',
         createdAt: new Date(job.metadata?.creationTimestamp || Date.now()),
-        status: job.status?.state?.phase || 'unknown',
+        status: job.status?.state?.phase?.toLowerCase() || 'unknown',
         yaml: job.yaml || '',
       }));
 
@@ -241,16 +241,16 @@ export default function JobsManagement() {
   const getStatusColor = (status: string) => {
     switch (status) {
       case "failed":
-      case "Terminated":
-        return "bg-red-100 text-red-800"
+      case "terminated":
+        return "bg-red-100 text-red-800 hover:bg-red-100/60"
       case "pending":
-        return "bg-yellow-100 text-yellow-800"
+        return "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
       case "running":
-        return "bg-blue-100 text-blue-800"
+        return "bg-blue-100 text-blue-800 hover:bg-blue-100/60"
       case "completed":
-        return "bg-green-100 text-green-800"
+        return "bg-green-100 text-green-800 hover:bg-green-100/60"
       default:
-        return "bg-gray-100 text-gray-800"
+        return "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
     }
   }
 

--- a/apps/web/src/components/(dashboard)/podgroups/columns.tsx
+++ b/apps/web/src/components/(dashboard)/podgroups/columns.tsx
@@ -171,15 +171,15 @@ export const createColumns = ({
                 return (
                     <Badge
                         className={
-                            status === "Running" || status === "running"
-                                ? "bg-green-100 text-green-800"
-                                : status === "Pending" || status === "pending"
-                                    ? "bg-yellow-100 text-yellow-800"
-                                    : status === "Failed" || status === "failed"
-                                        ? "bg-red-100 text-red-800"
-                                        : status === "Succeeded" || status === "succeeded"
-                                            ? "bg-blue-100 text-blue-800"
-                                            : "bg-gray-100 text-gray-800"
+                            status === "running"
+                                ? "bg-green-100 text-green-800 hover:bg-green-100/60"
+                                : status === "pending"
+                                    ? "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
+                                    : status === "failed"
+                                        ? "bg-red-100 text-red-800 hover:bg-red-100/60"
+                                        : status === "succeeded"
+                                            ? "bg-blue-100 text-blue-800 hover:bg-blue-100/60"
+                                            : "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
                         }
                     >
                         {status}
@@ -193,4 +193,3 @@ export const createColumns = ({
     ]
 
 export const columns = createColumns({ availableNamespaces: [], availableStatuses: [] })
-

--- a/apps/web/src/components/(dashboard)/podgroups/podgroup-management.tsx
+++ b/apps/web/src/components/(dashboard)/podgroups/podgroup-management.tsx
@@ -109,7 +109,7 @@ export default function PodGroupManagement() {
                         queue: pg.spec?.queue || '',
                         minMember: pg.spec?.minMember || 0,
                         createdAt,
-                        status: pg.status?.phase || 'Unknown',
+                        status: pg.status?.phase?.toLowerCase() || 'unknown',
                         yaml: pg.yaml || '',
                     };
                 });
@@ -169,19 +169,19 @@ export default function PodGroupManagement() {
     }
 
     const getStatusColor = (status: string) => {
-        switch (status.toLowerCase()) {
+        switch (status) {
             case "running":
-                return "bg-green-100 text-green-800"
+                return "bg-green-100 text-green-800 hover:bg-green-100/60"
             case "pending":
-                return "bg-yellow-100 text-yellow-800"
+                return "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
             case "failed":
-                return "bg-red-100 text-red-800"
+                return "bg-red-100 text-red-800 hover:bg-red-100/60"
             case "succeeded":
-                return "bg-blue-100 text-blue-800"
+                return "bg-blue-100 text-blue-800 hover:bg-blue-100/60"
             case "unknown":
-                return "bg-gray-100 text-gray-800"
+                return "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
             default:
-                return "bg-gray-100 text-gray-800"
+                return "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
         }
     }
 
@@ -358,4 +358,3 @@ export default function PodGroupManagement() {
         </div>
     )
 }
-

--- a/apps/web/src/components/(dashboard)/pods/columns.tsx
+++ b/apps/web/src/components/(dashboard)/pods/columns.tsx
@@ -152,14 +152,14 @@ export const createColumns = ({
                     <Badge
                         className={
                             status === "running"
-                                ? "bg-green-100 text-green-800"
+                                ? "bg-green-100 text-green-800 hover:bg-green-100/60"
                                 : status === "pending"
-                                    ? "bg-yellow-100 text-yellow-800"
+                                    ? "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
                                     : status === "failed"
-                                        ? "bg-red-100 text-red-800"
+                                        ? "bg-red-100 text-red-800 hover:bg-red-100/60"
                                         : status === "succeeded"
-                                            ? "bg-blue-100 text-blue-800"
-                                            : "bg-gray-100 text-gray-800"
+                                            ? "bg-blue-100 text-blue-800 hover:bg-blue-100/60"
+                                            : "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
                         }
                     >
                         {status}
@@ -230,4 +230,4 @@ export const createColumns = ({
         },
     ]
 
-export const columns = createColumns({ availableNamespaces: [], availableStatuses: [] }) 
+export const columns = createColumns({ availableNamespaces: [], availableStatuses: [] })

--- a/apps/web/src/components/(dashboard)/pods/pod-management.tsx
+++ b/apps/web/src/components/(dashboard)/pods/pod-management.tsx
@@ -235,17 +235,17 @@ export default function PodManagement() {
     const getStatusColor = (status: string) => {
         switch (status) {
             case "running":
-                return "bg-green-100 text-green-800"
+                return "bg-green-100 text-green-800 hover:bg-green-100/60"
             case "pending":
-                return "bg-yellow-100 text-yellow-800"
+                return "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
             case "failed":
-                return "bg-red-100 text-red-800"
+                return "bg-red-100 text-red-800 hover:bg-red-100/60"
             case "succeeded":
-                return "bg-blue-100 text-blue-800"
+                return "bg-blue-100 text-blue-800 hover:bg-blue-100/60"
             case "unknown":
-                return "bg-gray-100 text-gray-800"
+                return "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
             default:
-                return "bg-gray-100 text-gray-800"
+                return "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
         }
     }
 

--- a/apps/web/src/components/(dashboard)/queues/columns.tsx
+++ b/apps/web/src/components/(dashboard)/queues/columns.tsx
@@ -106,12 +106,12 @@ export const createColumns = ({ onEdit, onDelete }: CreateColumnsOptions): Colum
                 <Badge
                     className={
                         state === "open"
-                            ? "bg-green-100 text-green-800"
+                            ? "bg-green-100 text-green-800 hover:bg-green-100/60"
                             : state === "closed"
-                                ? "bg-red-100 text-red-800"
+                                ? "bg-red-100 text-red-800 hover:bg-red-100/60"
                                 : state === "maintenance"
-                                    ? "bg-yellow-100 text-yellow-800"
-                                    : "bg-gray-100 text-gray-800"
+                                    ? "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
+                                    : "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
                     }
                 >
                     {state}
@@ -190,4 +190,4 @@ export const createColumns = ({ onEdit, onDelete }: CreateColumnsOptions): Colum
     },
 ]
 
-export const columns = createColumns({}) 
+export const columns = createColumns({})

--- a/apps/web/src/components/(dashboard)/queues/queue-management.tsx
+++ b/apps/web/src/components/(dashboard)/queues/queue-management.tsx
@@ -233,13 +233,13 @@ export default function QueueManagement() {
     const getStateColor = (state: string) => {
         switch (state) {
             case "open":
-                return "bg-green-100 text-green-800"
+                return "bg-green-100 text-green-800 hover:bg-green-100/60"
             case "closed":
-                return "bg-red-100 text-red-800"
+                return "bg-red-100 text-red-800 hover:bg-red-100/60"
             case "maintenance":
-                return "bg-yellow-100 text-yellow-800"
+                return "bg-yellow-100 text-yellow-800 hover:bg-yellow-100/60"
             default:
-                return "bg-gray-100 text-gray-800"
+                return "bg-gray-100 text-gray-800 hover:bg-gray-100/60"
         }
     }
 

--- a/packages/trpc/server/router/helpers.ts
+++ b/packages/trpc/server/router/helpers.ts
@@ -212,14 +212,14 @@ export const fetchPodGroups = async (
 ): Promise<PaginatedResponse<unknown>> => {
     const namespace = filters.namespace?.trim() ?? "";
     const search = filters.search?.trim().toLowerCase() ?? "";
-    const status = filters.status?.trim() ?? "";
+    const status = filters.status?.trim().toLowerCase() ?? "";
 
     const matchesFilters = (pg: PodGroupLike) => {
         if (pg.metadata?.deletionTimestamp) return false;
         if (search && !String(pg.metadata?.name ?? "").toLowerCase().includes(search)) {
             return false;
         }
-        if (status && status !== "All" && pg.status?.phase !== status) {
+        if (status && status !== "all" && pg.status?.phase?.toLowerCase() !== status) {
             return false;
         }
         return true;


### PR DESCRIPTION
## Summary

fixes #289 

- Replace the default red hover color used by the affected badges with the intended theme hover color.

- Normalize job status values before applying the badge color mapping.

- Ensure the Completed job status resolves to the configured green badge color instead of falling back to the default red style.

## Screenshots:

Before 

<img width="1623" height="422" alt="Image" src="https://github.com/user-attachments/assets/a823adec-b724-4b6e-b5e5-f25a97d45cb2" />

<img width="1623" height="422" alt="Image" src="https://github.com/user-attachments/assets/0bca6f56-c547-4730-8bde-75a15fe0582d" />

After

<img width="1623" height="422" alt="image" src="https://github.com/user-attachments/assets/bbba8597-abdf-4779-a47a-939edb2d6108" />

<img width="1623" height="422" alt="image" src="https://github.com/user-attachments/assets/9a1451cb-e032-4fbe-bd06-a45897e6abce" />
