### PR TITLE
feat: add Netlify configuration and demo mode support for the Volcano dashboard

### DIFF
--- a/.github/workflows/e2e-kind.yml
+++ b/.github/workflows/e2e-kind.yml
@@ -1,0 +1,119 @@
+name: E2E Kind
+
+on:
+    pull_request:
+        branches: [main]
+    push:
+        branches: [main]
+
+permissions:
+    contents: read
+    pull-requests: write
+
+jobs:
+    e2e-kind:
+        name: Dashboard on Kind
+        runs-on: ubuntu-24.04
+        timeout-minutes: 45
+        steps:
+            - name: Free disk space
+              uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be
+              with:
+                  tool-cache: false
+                  android: true
+                  dotnet: true
+                  haskell: true
+                  large-packages: true
+                  docker-images: true
+                  swap-storage: true
+
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Install Kind and kubectl
+              run: |
+                  go install sigs.k8s.io/kind@v0.31.0
+                  curl -LO https://dl.k8s.io/release/v1.32.0/bin/linux/amd64/kubectl
+                  sudo install kubectl /usr/local/bin/kubectl
+                  echo "${HOME}/go/bin" >> "${GITHUB_PATH}"
+
+            - name: Run dashboard Kind smoke test
+              run: bash hack/run-e2e-kind.sh
+
+    netlify-build:
+        name: Netlify Build Check
+        runs-on: ubuntu-latest
+        env:
+            DASHBOARD_DEMO_MODE: "true"
+            NEXT_PUBLIC_DASHBOARD_DEMO_MODE: "true"
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v4
+
+            - name: Install Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version: 20
+                  cache: npm
+
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Verify Netlify build command
+              run: npm run build
+
+            - name: Publish Netlify deploy preview
+              id: netlify_deploy
+              if: github.event_name == 'pull_request' && vars.ENABLE_NETLIFY_PREVIEW == 'true'
+              env:
+                  NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+                  NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+              run: |
+                  DEPLOY_URL="$(npx --yes netlify-cli@23.9.1 deploy \
+                    --build \
+                    --context deploy-preview \
+                    --message "PR #${{ github.event.pull_request.number }}" \
+                    --json | node -e "const fs=require('fs'); const data=JSON.parse(fs.readFileSync(0,'utf8')); process.stdout.write(data.deploy_url || data.url || '')")"
+                  echo "deploy_url=${DEPLOY_URL}" >> "${GITHUB_OUTPUT}"
+
+            - name: Comment on pull request
+              if: github.event_name == 'pull_request' && steps.netlify_deploy.outputs.deploy_url != ''
+              uses: actions/github-script@v7
+              with:
+                  script: |
+                      const deployUrl = '${{ steps.netlify_deploy.outputs.deploy_url }}';
+                      const body = [
+                          '## Dashboard preview',
+                          '',
+                          `- **Netlify UI preview (demo data):** ${deployUrl}`,
+                          '- **Kind integration:** see the "Dashboard on Kind" check on this PR for real cluster validation.',
+                          '',
+                          'The Netlify preview uses read-only demo fixtures. The Kind job deploys the dashboard against a real Volcano cluster with sample workloads.',
+                      ].join('\n');
+
+                      const { data: comments } = await github.rest.issues.listComments({
+                          owner: context.repo.owner,
+                          repo: context.repo.repo,
+                          issue_number: context.issue.number,
+                      });
+
+                      const existing = comments.find((comment) =>
+                          comment.user?.type === 'Bot' &&
+                          comment.body?.includes('## Dashboard preview')
+                      );
+
+                      if (existing) {
+                          await github.rest.issues.updateComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              comment_id: existing.id,
+                              body,
+                          });
+                      } else {
+                          await github.rest.issues.createComment({
+                              owner: context.repo.owner,
+                              repo: context.repo.repo,
+                              issue_number: context.issue.number,
+                              body,
+                          });
+                      }

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,8 +1,17 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.join(__dirname, "../..");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    output: 'standalone',
+    output: "standalone",
     experimental: {
-        outputFileTracingRoot: undefined,
+        outputFileTracingRoot: repoRoot,
+        outputFileTracingIncludes: {
+            "/api/trpc/[trpc]": ["./examples/cluster-samples/**/*"],
+        },
     },
 };
 

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -10,7 +10,7 @@ const nextConfig = {
     experimental: {
         outputFileTracingRoot: repoRoot,
         outputFileTracingIncludes: {
-            "/api/trpc/[trpc]": ["./examples/cluster-samples/**/*"],
+            "/api/trpc/[trpc]": ["../../examples/cluster-samples/**/*"],
         },
     },
 };

--- a/apps/web/src/app/(dashboard)/layout.tsx
+++ b/apps/web/src/app/(dashboard)/layout.tsx
@@ -1,4 +1,5 @@
 import Sidebar from "@/components/(dashboard)/layout/sidebar";
+import { DemoBanner } from "@/components/(dashboard)/demo-banner";
 import React from "react";
 
 
@@ -8,11 +9,14 @@ type DashboardLayoutProps = {
 
 export default function DashboardLayout({ children }: DashboardLayoutProps) {
   return (
-    <div className="flex">
-        <Sidebar />
-        <main className="w-full flex-1 overflow-hidden">
-            {children}
-        </main>
+    <div className="flex min-h-screen flex-col">
+        <DemoBanner />
+        <div className="flex flex-1">
+            <Sidebar />
+            <main className="w-full flex-1 overflow-hidden">
+                {children}
+            </main>
+        </div>
     </div>
   )
 }

--- a/apps/web/src/components/(dashboard)/demo-banner.tsx
+++ b/apps/web/src/components/(dashboard)/demo-banner.tsx
@@ -1,0 +1,12 @@
+export function DemoBanner() {
+    if (process.env.NEXT_PUBLIC_DASHBOARD_DEMO_MODE !== "true") {
+        return null;
+    }
+
+    return (
+        <div className="border-b border-amber-200 bg-amber-50 px-4 py-2 text-center text-sm text-amber-900">
+            Preview mode — demo data only, not connected to a live cluster.
+            Create, edit, and delete actions are disabled.
+        </div>
+    );
+}

--- a/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
+++ b/apps/web/src/components/(dashboard)/jobs/jobs-management.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
 import { usePaginationClamp } from "@/hooks/use-pagination-clamp"
+import { useDemoMode } from "@/hooks/use-demo-mode"
 import { trpc } from "@volcano/trpc/react"
 import { Plus, RefreshCw } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
@@ -30,6 +31,7 @@ export type JobStatus = {
 }
 
 export default function JobsManagement() {
+  const isDemoMode = useDemoMode()
   const [jobs, setJobs] = useState<JobStatus[]>()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -159,8 +161,8 @@ export default function JobsManagement() {
     availableNamespaces,
     availableQueues,
     availableStatuses,
-    onEdit: handleEdit,
-    onDelete: handleDelete
+    onEdit: isDemoMode ? undefined : handleEdit,
+    onDelete: isDemoMode ? undefined : handleDelete
   });
 
   // Use tRPC query results to update state
@@ -271,10 +273,12 @@ export default function JobsManagement() {
             <RefreshCw className={`h-4 w-4 ${(loading || isRefreshing) ? 'animate-spin' : ''}`} />
             Refresh
           </Button>
-          <Button onClick={handleJobCreate} className="flex items-center gap-2">
-            <Plus className="h-4 w-4" />
-            Create Job
-          </Button>
+          {!isDemoMode && (
+            <Button onClick={handleJobCreate} className="flex items-center gap-2">
+              <Plus className="h-4 w-4" />
+              Create Job
+            </Button>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/components/(dashboard)/pods/pod-management.tsx
+++ b/apps/web/src/components/(dashboard)/pods/pod-management.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
 import { usePaginationClamp } from "@/hooks/use-pagination-clamp"
+import { useDemoMode } from "@/hooks/use-demo-mode"
 import { trpc } from "@volcano/trpc/react"
 import { Plus, RefreshCw } from "lucide-react"
 import { useCallback, useEffect, useState } from "react"
@@ -34,6 +35,7 @@ export type PodStatus = {
 }
 
 export default function PodManagement() {
+    const isDemoMode = useDemoMode()
     const [pods, setPods] = useState<PodStatus[]>()
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
@@ -151,8 +153,8 @@ export default function PodManagement() {
     const columns = createColumns({
         availableNamespaces,
         availableStatuses,
-        onEdit: handleEdit,
-        onDelete: handleDelete
+        onEdit: isDemoMode ? undefined : handleEdit,
+        onDelete: isDemoMode ? undefined : handleDelete
     });
 
     useEffect(() => {
@@ -265,10 +267,12 @@ export default function PodManagement() {
                         <RefreshCw className={`h-4 w-4 ${(loading || isRefreshing) ? 'animate-spin' : ''}`} />
                         Refresh
                     </Button>
-                    <Button onClick={handlePodCreate} className="flex items-center gap-2">
-                        <Plus className="h-4 w-4" />
-                        Create Pod
-                    </Button>
+                    {!isDemoMode && (
+                        <Button onClick={handlePodCreate} className="flex items-center gap-2">
+                            <Plus className="h-4 w-4" />
+                            Create Pod
+                        </Button>
+                    )}
                 </div>
             </div>
 

--- a/apps/web/src/components/(dashboard)/queues/queue-management.tsx
+++ b/apps/web/src/components/(dashboard)/queues/queue-management.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
 import { usePaginationClamp } from "@/hooks/use-pagination-clamp"
+import { useDemoMode } from "@/hooks/use-demo-mode"
 import { trpc } from "@volcano/trpc/react"
 import { Plus, RefreshCw } from "lucide-react"
 import { ListPagination } from "../list-pagination"
@@ -31,6 +32,7 @@ export type QueueStatus = {
 }
 
 export default function QueueManagement() {
+    const isDemoMode = useDemoMode()
     const [queues, setQueues] = useState<QueueStatus[]>()
     const [loading, setLoading] = useState(false)
     const [error, setError] = useState<string | null>(null)
@@ -147,8 +149,8 @@ export default function QueueManagement() {
     }, [queueToDelete, deleteQueue])
 
     const columns = createColumns({
-        onEdit: handleEdit,
-        onDelete: handleDelete
+        onEdit: isDemoMode ? undefined : handleEdit,
+        onDelete: isDemoMode ? undefined : handleDelete
     })
 
     const queueYamlQuery = trpc.queueRouter.getQueueYaml.useQuery(
@@ -259,10 +261,12 @@ export default function QueueManagement() {
                         <RefreshCw className={`h-4 w-4 ${(loading || isRefreshing) ? 'animate-spin' : ''}`} />
                         Refresh
                     </Button>
-                    <Button onClick={handleCreateQueue} className="flex items-center gap-2">
-                        <Plus className="h-4 w-4" />
-                        Create Queue
-                    </Button>
+                    {!isDemoMode && (
+                        <Button onClick={handleCreateQueue} className="flex items-center gap-2">
+                            <Plus className="h-4 w-4" />
+                            Create Queue
+                        </Button>
+                    )}
                 </div>
             </div>
 

--- a/apps/web/src/hooks/use-demo-mode.ts
+++ b/apps/web/src/hooks/use-demo-mode.ts
@@ -1,0 +1,3 @@
+export function useDemoMode(): boolean {
+    return process.env.NEXT_PUBLIC_DASHBOARD_DEMO_MODE === "true";
+}

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -45,12 +45,9 @@ RUN adduser --system --uid 1001 nextjs
 RUN mkdir -p apps/web/.next/cache && \
     chown nextjs:nodejs apps/web/.next/cache
 
-# Copy the entire standalone output to root
+# Monorepo standalone layout: server.js and static assets live under apps/web/.
 COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./.next/static
-
-# The public directory is often handled by the standalone output.
-# If it's missing, this COPY command will fail. It's removed.
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
 
 USER nextjs
 
@@ -58,5 +55,4 @@ EXPOSE 8080
 ENV PORT=8080
 ENV HOSTNAME="0.0.0.0"
 
-# The standalone output places server.js in the root
-CMD ["node", "server.js"]
+CMD ["node", "apps/web/server.js"]

--- a/deployment/volcano-dashboard.yaml
+++ b/deployment/volcano-dashboard.yaml
@@ -42,7 +42,7 @@ spec:
               drop:
               - ALL
             runAsNonRoot: true
-            runAsUser: 1000
+            runAsUser: 1001
 ---
 # Volcano Dashboard ServiceAccount
 apiVersion: v1

--- a/examples/cluster-samples/00-namespaces.yaml
+++ b/examples/cluster-samples/00-namespaces.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volcano-demo
+  labels:
+    demo.volcano.sh/sample: "true"
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: volcano-demo-ops
+  labels:
+    demo.volcano.sh/sample: "true"

--- a/examples/cluster-samples/10-queues.yaml
+++ b/examples/cluster-samples/10-queues.yaml
@@ -1,0 +1,62 @@
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: demo-root
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  weight: 1
+  reclaimable: false
+  capability:
+    cpu: "8"
+    memory: 16Gi
+status:
+  state: Open
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: demo-prod
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  parent: demo-root
+  weight: 2
+  reclaimable: true
+  capability:
+    cpu: "4"
+    memory: 8Gi
+status:
+  state: Open
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: demo-dev
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  parent: demo-root
+  weight: 1
+  reclaimable: true
+  capability:
+    cpu: "2"
+    memory: 4Gi
+status:
+  state: Open
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: Queue
+metadata:
+  name: demo-research
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  parent: demo-root
+  weight: 1
+  reclaimable: true
+  capability:
+    cpu: "2"
+    memory: 4Gi
+status:
+  state: Open

--- a/examples/cluster-samples/20-podgroups.yaml
+++ b/examples/cluster-samples/20-podgroups.yaml
@@ -1,0 +1,32 @@
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: demo-serving
+  namespace: volcano-demo
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  minMember: 2
+  queue: demo-prod
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: demo-pending
+  namespace: volcano-demo
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  minMember: 2
+  queue: demo-research
+---
+apiVersion: scheduling.volcano.sh/v1beta1
+kind: PodGroup
+metadata:
+  name: demo-ops-maintenance
+  namespace: volcano-demo-ops
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  minMember: 1
+  queue: demo-dev

--- a/examples/cluster-samples/30-pods.yaml
+++ b/examples/cluster-samples/30-pods.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-serving-0
+  namespace: volcano-demo
+  labels:
+    app: demo-serving
+    demo.volcano.sh/sample: "true"
+    scheduling.volcano.sh/group-name: demo-serving
+    scheduling.volcano.sh/queue-name: demo-prod
+spec:
+  containers:
+    - name: main
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 86400"]
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-serving-1
+  namespace: volcano-demo
+  labels:
+    app: demo-serving
+    demo.volcano.sh/sample: "true"
+    scheduling.volcano.sh/group-name: demo-serving
+    scheduling.volcano.sh/queue-name: demo-prod
+spec:
+  containers:
+    - name: main
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 86400"]
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-pending-0
+  namespace: volcano-demo
+  labels:
+    app: demo-pending
+    demo.volcano.sh/sample: "true"
+    scheduling.volcano.sh/group-name: demo-pending
+    scheduling.volcano.sh/queue-name: demo-research
+spec:
+  containers:
+    - name: main
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 86400"]
+  nodeSelector:
+    kubernetes.io/hostname: demo-unreachable-node
+status:
+  phase: Pending
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-ops-agent
+  namespace: volcano-demo-ops
+  labels:
+    app: demo-ops-agent
+    demo.volcano.sh/sample: "true"
+    scheduling.volcano.sh/queue-name: demo-dev
+spec:
+  containers:
+    - name: main
+      image: busybox:1.36
+      command: ["sh", "-c", "sleep 86400"]
+status:
+  phase: Running
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-failed-task
+  namespace: volcano-demo-ops
+  labels:
+    app: demo-failed-task
+    demo.volcano.sh/sample: "true"
+    scheduling.volcano.sh/queue-name: demo-dev
+spec:
+  containers:
+    - name: main
+      image: busybox:1.36
+      command: ["sh", "-c", "exit 1"]
+status:
+  phase: Failed
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: demo-succeeded-task
+  namespace: volcano-demo-ops
+  labels:
+    app: demo-succeeded-task
+    demo.volcano.sh/sample: "true"
+    scheduling.volcano.sh/queue-name: demo-dev
+spec:
+  containers:
+    - name: main
+      image: busybox:1.36
+      command: ["sh", "-c", "echo done"]
+status:
+  phase: Succeeded

--- a/examples/cluster-samples/40-jobs.yaml
+++ b/examples/cluster-samples/40-jobs.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: demo-job-prod
+  namespace: volcano-demo
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  minAvailable: 1
+  queue: demo-prod
+  tasks:
+    - replicas: 1
+      name: task
+      template:
+        spec:
+          containers:
+            - name: main
+              image: busybox:1.36
+              command: ["sh", "-c", "echo demo-job-prod; sleep 86400"]
+          restartPolicy: Never
+status:
+  state:
+    phase: Running
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: demo-job-dev
+  namespace: volcano-demo-ops
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  minAvailable: 1
+  queue: demo-dev
+  tasks:
+    - replicas: 1
+      name: task
+      template:
+        spec:
+          containers:
+            - name: main
+              image: busybox:1.36
+              command: ["sh", "-c", "echo demo-job-dev; sleep 86400"]
+          restartPolicy: Never
+status:
+  state:
+    phase: Running
+---
+apiVersion: batch.volcano.sh/v1alpha1
+kind: Job
+metadata:
+  name: demo-job-completed
+  namespace: volcano-demo
+  labels:
+    demo.volcano.sh/sample: "true"
+spec:
+  minAvailable: 1
+  queue: demo-research
+  tasks:
+    - replicas: 1
+      name: task
+      template:
+        spec:
+          containers:
+            - name: main
+              image: busybox:1.36
+              command: ["sh", "-c", "echo done"]
+          restartPolicy: Never
+status:
+  state:
+    phase: Completed

--- a/hack/e2e-kind-config.yaml
+++ b/hack/e2e-kind-config.yaml
@@ -1,0 +1,4 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -39,10 +39,17 @@ kind load docker-image "${IMAGE_TAG}" --name "${CLUSTER_NAME}"
 
 echo "Deploying volcano dashboard..."
 kubectl create ns volcano-system --dry-run=client -o yaml | kubectl apply -f -
-kubectl apply -f "${ROOT}/deployment/volcano-dashboard.yaml"
-kubectl -n volcano-system set image deploy/volcano-dashboard \
-    volcano-dashboard="${IMAGE_TAG}"
-kubectl -n volcano-system rollout status deploy/volcano-dashboard --timeout=300s
+sed -e "s|image: volcanosh/volcano-dashboard:.*|image: ${IMAGE_TAG}|" \
+    -e "s|imagePullPolicy: IfNotPresent|imagePullPolicy: Never|" \
+    "${ROOT}/deployment/volcano-dashboard.yaml" | kubectl apply -f -
+if ! kubectl -n volcano-system rollout status deploy/volcano-dashboard --timeout=300s; then
+    echo "Dashboard deployment failed; collecting diagnostics..." >&2
+    kubectl -n volcano-system get pods -l app=volcano-dashboard -o wide >&2 || true
+    kubectl -n volcano-system describe deploy/volcano-dashboard >&2 || true
+    kubectl -n volcano-system describe pods -l app=volcano-dashboard >&2 || true
+    kubectl -n volcano-system logs -l app=volcano-dashboard --tail=200 >&2 || true
+    exit 1
+fi
 
 echo "Installing sample cluster resources..."
 kubectl apply -f "${ROOT}/examples/cluster-samples/"
@@ -96,4 +103,5 @@ fi
 
 echo "Dashboard smoke test passed."
 
-bash "${ROOT}/hack/smoke-test-dashboard.sh"
+echo "Running API smoke checks..."
+BASE_URL="http://127.0.0.1:${PORT_FORWARD_PORT}" bash "${ROOT}/hack/smoke-test-dashboard.sh"

--- a/hack/run-e2e-kind.sh
+++ b/hack/run-e2e-kind.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLUSTER_NAME="${CLUSTER_NAME:-dashboard-e2e}"
+IMAGE_TAG="${IMAGE_TAG:-volcano-dashboard-e2e:local}"
+VOLCANO_INSTALLER_URL="${VOLCANO_INSTALLER_URL:-https://raw.githubusercontent.com/volcano-sh/volcano/master/installer/volcano-development.yaml}"
+CLEANUP_CLUSTER="${CLEANUP_CLUSTER:-1}"
+PORT_FORWARD_PORT="${PORT_FORWARD_PORT:-18080}"
+
+cleanup() {
+    if [[ "${CLEANUP_CLUSTER}" == "1" ]]; then
+        kind delete cluster --name "${CLUSTER_NAME}" || true
+    fi
+}
+
+if [[ "${CLEANUP_CLUSTER}" == "1" ]]; then
+    trap cleanup EXIT
+fi
+
+echo "Creating Kind cluster ${CLUSTER_NAME}..."
+if kind get clusters | grep -qx "${CLUSTER_NAME}"; then
+    kind delete cluster --name "${CLUSTER_NAME}"
+fi
+kind create cluster --name "${CLUSTER_NAME}" --config "${ROOT}/hack/e2e-kind-config.yaml" --wait 120s
+
+echo "Installing Volcano..."
+kubectl apply -f "${VOLCANO_INSTALLER_URL}"
+kubectl -n volcano-system rollout status deploy/volcano-controllers --timeout=300s
+kubectl -n volcano-system rollout status deploy/volcano-scheduler --timeout=300s
+kubectl -n volcano-system rollout status deploy/volcano-admission --timeout=300s
+
+echo "Building dashboard image ${IMAGE_TAG}..."
+docker build -f "${ROOT}/deployment/Dockerfile" -t "${IMAGE_TAG}" "${ROOT}"
+
+echo "Loading dashboard image into Kind..."
+kind load docker-image "${IMAGE_TAG}" --name "${CLUSTER_NAME}"
+
+echo "Deploying volcano dashboard..."
+kubectl create ns volcano-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl apply -f "${ROOT}/deployment/volcano-dashboard.yaml"
+kubectl -n volcano-system set image deploy/volcano-dashboard \
+    volcano-dashboard="${IMAGE_TAG}"
+kubectl -n volcano-system rollout status deploy/volcano-dashboard --timeout=300s
+
+echo "Installing sample cluster resources..."
+kubectl apply -f "${ROOT}/examples/cluster-samples/"
+
+echo "Waiting for sample resources to appear..."
+for attempt in $(seq 1 30); do
+    queue_count="$(kubectl get queues.scheduling.volcano.sh 2>/dev/null | grep -c demo- || true)"
+    job_count="$(kubectl get jobs.batch.volcano.sh -A 2>/dev/null | grep -c demo- || true)"
+    if [[ "${queue_count}" -ge 3 && "${job_count}" -ge 2 ]]; then
+        break
+    fi
+    sleep 2
+    if [[ "${attempt}" -eq 30 ]]; then
+        echo "Sample resources did not become ready in time" >&2
+        kubectl get queues.scheduling.volcano.sh || true
+        kubectl get jobs.batch.volcano.sh -A || true
+        exit 1
+    fi
+done
+
+echo "Running dashboard smoke test..."
+kubectl -n volcano-system port-forward svc/volcano-dashboard "${PORT_FORWARD_PORT}:80" >/tmp/dashboard-port-forward.log 2>&1 &
+PORT_FORWARD_PID=$!
+
+cleanup_all() {
+    if [[ -n "${PORT_FORWARD_PID:-}" ]]; then
+        kill "${PORT_FORWARD_PID}" 2>/dev/null || true
+    fi
+    cleanup
+}
+
+trap cleanup_all EXIT
+
+for attempt in $(seq 1 30); do
+    if curl -sf "http://127.0.0.1:${PORT_FORWARD_PORT}/" >/tmp/dashboard-home.html; then
+        break
+    fi
+    sleep 2
+    if [[ "${attempt}" -eq 30 ]]; then
+        echo "Dashboard did not become reachable on port ${PORT_FORWARD_PORT}" >&2
+        cat /tmp/dashboard-port-forward.log >&2 || true
+        exit 1
+    fi
+done
+
+if ! grep -qi "volcano" /tmp/dashboard-home.html; then
+    echo "Dashboard home page did not contain expected content" >&2
+    head -c 500 /tmp/dashboard-home.html >&2 || true
+    exit 1
+fi
+
+echo "Dashboard smoke test passed."
+
+bash "${ROOT}/hack/smoke-test-dashboard.sh"

--- a/hack/smoke-test-dashboard.sh
+++ b/hack/smoke-test-dashboard.sh
@@ -1,13 +1,35 @@
-summary_response="$(curl -sf -X POST "${BASE_URL}/api/trpc/dashboardRouter.getSummary" \
-    -H "content-type: application/json" \
-    -d '{"json":null}')"
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BASE_URL="${BASE_URL:?BASE_URL must be set (e.g. http://127.0.0.1:18080)}"
+
+trpc_get() {
+    local procedure="$1"
+    local input_json="${2:-}"
+    local url="${BASE_URL}/api/trpc/${procedure}"
+    if [[ -n "${input_json}" ]]; then
+        local encoded
+        encoded="$(python3 -c 'import json,sys,urllib.parse; print(urllib.parse.quote(json.dumps({"json": json.loads(sys.argv[1])})))' "${input_json}")"
+        url="${url}?input=${encoded}"
+    fi
+    curl -sf "${url}"
+}
+
+echo "Checking dashboardRouter.getSummary..."
+summary_response="$(trpc_get "dashboardRouter.getSummary")"
 if ! echo "${summary_response}" | grep -q '"totalJobs"'; then
     echo "dashboardRouter.getSummary did not return expected payload" >&2
     echo "${summary_response}" >&2
     exit 1
 fi
 
-queues_response="$(curl -sf -X POST "${BASE_URL}/api/trpc/queueRouter.getQueues" \
-    -H "content-type: application/json" \
-    -d '{"json":{"page":1,"pageSize":10}}')"
+echo "Checking queueRouter.getQueues..."
+queues_response="$(trpc_get "queueRouter.getQueues" '{"page":1,"pageSize":10}')"
 if ! echo "${queues_response}" | grep -q 'demo-'; then
+    echo "queueRouter.getQueues did not return demo queues" >&2
+    echo "${queues_response}" >&2
+    exit 1
+fi
+
+echo "API smoke checks passed."

--- a/hack/smoke-test-dashboard.sh
+++ b/hack/smoke-test-dashboard.sh
@@ -1,0 +1,13 @@
+summary_response="$(curl -sf -X POST "${BASE_URL}/api/trpc/dashboardRouter.getSummary" \
+    -H "content-type: application/json" \
+    -d '{"json":null}')"
+if ! echo "${summary_response}" | grep -q '"totalJobs"'; then
+    echo "dashboardRouter.getSummary did not return expected payload" >&2
+    echo "${summary_response}" >&2
+    exit 1
+fi
+
+queues_response="$(curl -sf -X POST "${BASE_URL}/api/trpc/queueRouter.getQueues" \
+    -H "content-type: application/json" \
+    -d '{"json":{"page":1,"pageSize":10}}')"
+if ! echo "${queues_response}" | grep -q 'demo-'; then

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,15 @@
+# Netlify build settings for the Volcano dashboard monorepo.
+# The dashboard needs a Kubernetes API at runtime, so full interactive previews
+# are validated in GitHub Actions with a Kind cluster (see hack/run-e2e-kind.sh).
+# Netlify is used here to verify production builds and optional deploy previews.
+
+[build]
+  command = "npm ci && npm run build"
+
+[build.environment]
+  NODE_VERSION = "20"
+  DASHBOARD_DEMO_MODE = "true"
+  NEXT_PUBLIC_DASHBOARD_DEMO_MODE = "true"
+
+[[plugins]]
+  package = "@netlify/plugin-nextjs"

--- a/package-lock.json
+++ b/package-lock.json
@@ -254,10 +254,6 @@
         "node": ">=6.0.0"
       }
     },
-    "apps/web/node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.0",
-      "license": "MIT"
-    },
     "apps/web/node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
       "license": "MIT",
@@ -2631,7 +2627,6 @@
       "version": "18.3.18",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -2641,7 +2636,6 @@
       "version": "18.3.5",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -2678,7 +2672,6 @@
       "version": "8.23.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.23.0",
         "@typescript-eslint/types": "8.23.0",
@@ -2853,7 +2846,6 @@
       "version": "8.14.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3803,7 +3795,6 @@
       "version": "8.57.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3960,7 +3951,6 @@
       "version": "2.31.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -5302,22 +5292,6 @@
         "thenify-all": "^1.0.0"
       }
     },
-    "apps/web/node_modules/nanoid": {
-      "version": "3.3.8",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "apps/web/node_modules/natural-compare": {
       "version": "1.4.0",
       "dev": true,
@@ -5628,10 +5602,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "apps/web/node_modules/picocolors": {
-      "version": "1.1.1",
-      "license": "ISC"
-    },
     "apps/web/node_modules/picomatch": {
       "version": "2.3.1",
       "license": "MIT",
@@ -5681,7 +5651,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.8",
         "picocolors": "^1.1.1",
@@ -5840,7 +5809,6 @@
     "apps/web/node_modules/react": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5851,7 +5819,6 @@
     "apps/web/node_modules/react-dom": {
       "version": "18.3.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6635,7 +6602,6 @@
     "apps/web/node_modules/tailwindcss": {
       "version": "3.4.17",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6845,7 +6811,6 @@
       "version": "5.7.3",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7178,15 +7143,446 @@
         }
       }
     },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
+      "os": [
+        "aix"
+      ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -7419,6 +7815,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
@@ -7433,6 +7830,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -7443,27 +7841,11 @@
         "@img/sharp-libvips-linux-x64": "1.1.0"
       }
     },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.4",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jsep-plugin/assignment": {
       "version": "1.3.0",
@@ -7515,7 +7897,8 @@
     },
     "node_modules/@next/env": {
       "version": "15.3.5",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@next/eslint-plugin-next": {
       "version": "15.3.5",
@@ -7537,6 +7920,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7553,6 +7937,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7569,6 +7954,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7585,6 +7971,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7599,6 +7986,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7615,6 +8003,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7631,6 +8020,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7647,6 +8037,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7663,6 +8054,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -7708,13 +8100,404 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -7737,7 +8520,6 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@trpc/server": "10.45.2"
       }
@@ -7749,15 +8531,13 @@
       "funding": [
         "https://trpc.io/sponsor"
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@ts-rest/core": {
       "version": "3.52.1",
       "resolved": "https://registry.npmjs.org/@ts-rest/core/-/core-3.52.1.tgz",
       "integrity": "sha512-tAjz7Kxq/grJodcTA1Anop4AVRDlD40fkksEV5Mmal88VoZeRKAG8oMHsDwdwPZz+B/zgnz0q2sF+cm5M7Bc7g==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/node": "^18.18.7 || >=20.8.4",
         "zod": "^3.22.3"
@@ -7771,28 +8551,28 @@
         }
       }
     },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.11",
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
     },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.4",
-      "license": "MIT",
-      "optional": true
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
     "node_modules/@types/js-yaml": {
@@ -7810,7 +8590,6 @@
     "node_modules/@types/node": {
       "version": "22.16.0",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -7884,7 +8663,6 @@
       "version": "8.35.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.35.1",
         "@typescript-eslint/types": "8.35.1",
@@ -8080,6 +8858,121 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volcano/eslint-config": {
       "resolved": "packages/eslint-config",
       "link": true
@@ -8108,7 +9001,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -8121,17 +9013,6 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.4",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "acorn": "^8.11.0"
-      },
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -8169,11 +9050,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -8301,6 +9177,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-function": {
@@ -8434,6 +9320,7 @@
     },
     "node_modules/busboy": {
       "version": "1.6.0",
+      "peer": true,
       "dependencies": {
         "streamsearch": "^1.1.0"
       },
@@ -8448,6 +9335,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind": {
@@ -8515,7 +9412,25 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "peer": true
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -8531,9 +9446,20 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/co-body": {
       "version": "6.2.0",
@@ -8555,6 +9481,7 @@
       "version": "4.2.3",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1",
         "color-string": "^1.9.0"
@@ -8581,6 +9508,7 @@
       "version": "1.9.1",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
@@ -8634,11 +9562,6 @@
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
       }
-    },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -8730,6 +9653,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "license": "MIT"
@@ -8800,16 +9733,9 @@
       "version": "2.0.4",
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "license": "BSD-3-Clause",
-      "optional": true,
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/doctrine": {
@@ -8959,6 +9885,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
@@ -9009,6 +9942,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "license": "MIT",
@@ -9024,7 +9999,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.32.0.tgz",
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -9268,11 +10242,31 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -9416,6 +10410,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
@@ -9547,7 +10555,8 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -9786,7 +10795,8 @@
     "node_modules/is-arrayish": {
       "version": "0.3.2",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -10193,7 +11203,6 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -10293,10 +11302,22 @@
         "loose-envify": "cli.js"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "license": "ISC",
-      "optional": true
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -10404,7 +11425,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
       "funding": [
         {
           "type": "github",
@@ -10435,6 +11458,7 @@
     "node_modules/next": {
       "version": "15.3.5",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.3.5",
         "@swc/counter": "0.1.3",
@@ -10523,6 +11547,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10539,6 +11564,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10555,6 +11581,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10571,6 +11598,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10587,6 +11615,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10603,6 +11632,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10619,6 +11649,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -10907,8 +11938,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/picocolors": {
-      "version": "1.0.1",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -10947,6 +11997,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -10961,7 +12012,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -11192,6 +12242,51 @@
       "integrity": "sha512-rRg/6Lb+IGfJqO05HZkN50UtY7K/JhxJag1kP23+zyMfrvoB0B7RWv06MbOzoc79RgCdNTiUaNsTT1AJZ7Z+cg==",
       "license": "MIT"
     },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "dev": true,
@@ -11287,7 +12382,8 @@
     },
     "node_modules/scheduler": {
       "version": "0.26.0",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/semver": {
       "version": "7.6.2",
@@ -11354,6 +12450,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "color": "^4.2.3",
         "detect-libc": "^2.0.4",
@@ -11393,6 +12490,7 @@
       "version": "7.7.2",
       "license": "ISC",
       "optional": true,
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -11481,10 +12579,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/simple-swizzle": {
       "version": "0.2.2",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-arrayish": "^0.3.1"
       }
@@ -11540,6 +12646,13 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
@@ -11548,6 +12661,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -11572,6 +12692,7 @@
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       }
@@ -11687,9 +12808,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },
@@ -11775,6 +12917,98 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "dev": true,
@@ -11841,13 +13075,13 @@
     },
     "node_modules/tslib": {
       "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/turbo": {
       "version": "2.5.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "turbo": "bin/turbo"
       },
@@ -12037,9 +13271,8 @@
     },
     "node_modules/typescript": {
       "version": "5.8.2",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12140,10 +13373,249 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
+    "node_modules/vite": {
+      "version": "7.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.6.tgz",
+      "integrity": "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==",
+      "dev": true,
       "license": "MIT",
-      "optional": true
+      "dependencies": {
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/web": {
       "resolved": "apps/web",
@@ -12259,6 +13731,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "license": "MIT",
@@ -12277,7 +13766,6 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -12292,14 +13780,6 @@
         "utf-8-validate": {
           "optional": true
         }
-      }
-    },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -12317,7 +13797,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.72.tgz",
       "integrity": "sha512-Cl+fe4dNL4XumOBNBsr0lHfA80PQiZXHI4xEMTEr8gt6aGz92t3lBA32e71j9+JeF/VAYvdfBnuwJs+BMx/BrA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -12362,6 +13841,7 @@
         "@ts-rest/core": "^3.30.5",
         "@ts-rest/next": "^3.30.5",
         "eslint": "^9.32.0",
+        "js-yaml": "^4.1.0",
         "next-auth": "^5.0.0-beta.20",
         "react": "^18.3.1",
         "superjson": "^1.13.1",
@@ -12370,14 +13850,16 @@
         "zod": "^3.22.4"
       },
       "devDependencies": {
-        "@types/react": "^19.1.8"
+        "@types/react": "^19.1.8",
+        "vitest": "^3.2.6"
       }
     },
     "packages/trpc/node_modules/@next/env": {
       "version": "14.2.30",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.30.tgz",
       "integrity": "sha512-KBiBKrDY6kxTQWGzKjQB7QirL3PiiOkV7KW98leHFjtVRKtft76Ra5qSA/SL75xT44dp6hOcqiiJ6iievLOYug==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "packages/trpc/node_modules/@next/swc-linux-x64-gnu": {
       "version": "14.2.30",
@@ -12391,6 +13873,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -12400,6 +13883,7 @@
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
       "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "tslib": "^2.4.0"
@@ -12410,7 +13894,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.40.0.tgz",
       "integrity": "sha512-kt1G/wETT/Ad79cac5zJ8tyaMOm4rgyeomW5yDxgOO9qEhOwufgw9kgPpp+T9U0M0lL7EMoc6YXgv4gYhXu9tg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "4.40.0",
         "use-sync-external-store": "^1.2.0"
@@ -12459,7 +13942,6 @@
         "https://trpc.io/sponsor"
       ],
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@tanstack/react-query": "^4.18.0",
         "@trpc/client": "10.45.2",
@@ -12540,7 +14022,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -12567,6 +14048,7 @@
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -12576,6 +14058,7 @@
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
       "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "client-only": "0.0.1"
       },

--- a/packages/trpc/package.json
+++ b/packages/trpc/package.json
@@ -8,7 +8,8 @@
     "scripts": {
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
-        "clean": "rimraf node_modules"
+        "clean": "rimraf node_modules",
+        "test": "vitest run"
     },
     "dependencies": {
         "@kubernetes/client-node": "^1.3.0",
@@ -20,6 +21,7 @@
         "@ts-rest/core": "^3.30.5",
         "@ts-rest/next": "^3.30.5",
         "eslint": "^9.32.0",
+        "js-yaml": "^4.1.0",
         "next-auth": "^5.0.0-beta.20",
         "react": "^18.3.1",
         "superjson": "^1.13.1",
@@ -28,6 +30,7 @@
         "zod": "^3.22.4"
     },
     "devDependencies": {
-        "@types/react": "^19.1.8"
+        "@types/react": "^19.1.8",
+        "vitest": "^3.2.6"
     }
 }

--- a/packages/trpc/server/demo/fixtures.ts
+++ b/packages/trpc/server/demo/fixtures.ts
@@ -1,0 +1,75 @@
+import fs from "fs";
+import path from "path";
+import yaml from "js-yaml";
+
+type K8sObject = {
+    apiVersion?: string;
+    kind?: string;
+    metadata?: { name?: string; namespace?: string; deletionTimestamp?: unknown };
+    spec?: Record<string, unknown>;
+    status?: Record<string, unknown>;
+};
+
+const FIXTURE_FILES = [
+    "00-namespaces.yaml",
+    "10-queues.yaml",
+    "20-podgroups.yaml",
+    "30-pods.yaml",
+    "40-jobs.yaml",
+];
+
+let cached: {
+    queues: K8sObject[];
+    jobs: K8sObject[];
+    pods: K8sObject[];
+    podgroups: K8sObject[];
+} | null = null;
+
+function resolveSamplesDir(): string {
+    let dir = process.cwd();
+    for (let depth = 0; depth < 6; depth += 1) {
+        const candidate = path.join(dir, "examples", "cluster-samples");
+        if (fs.existsSync(candidate)) {
+            return candidate;
+        }
+        const parent = path.dirname(dir);
+        if (parent === dir) {
+            break;
+        }
+        dir = parent;
+    }
+    throw new Error(
+        "Could not locate examples/cluster-samples. Run from the repository root.",
+    );
+}
+
+function loadDocuments(filePath: string): K8sObject[] {
+    const raw = fs.readFileSync(filePath, "utf8");
+    return yaml.loadAll(raw).filter(Boolean) as K8sObject[];
+}
+
+export function loadDemoFixtures() {
+    if (cached) {
+        return cached;
+    }
+
+    const samplesDir = resolveSamplesDir();
+    const all: K8sObject[] = [];
+
+    for (const file of FIXTURE_FILES) {
+        all.push(...loadDocuments(path.join(samplesDir, file)));
+    }
+
+    cached = {
+        queues: all.filter((item) => item.kind === "Queue"),
+        jobs: all.filter((item) => item.kind === "Job"),
+        pods: all.filter((item) => item.kind === "Pod"),
+        podgroups: all.filter((item) => item.kind === "PodGroup"),
+    };
+
+    return cached;
+}
+
+export function resetDemoFixturesCache() {
+    cached = null;
+}

--- a/packages/trpc/server/demo/handlers.test.ts
+++ b/packages/trpc/server/demo/handlers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { TRPCError } from "@trpc/server";
+import { resetDemoFixturesCache } from "./fixtures";
+import {
+    getDemoJobs,
+    getDemoPodGroups,
+    getDemoPods,
+    getDemoQueues,
+    getDemoSummary,
+} from "./handlers";
+import { assertDemoWritable } from "../utils/demo";
+
+describe("demo handlers", () => {
+    it("returns non-empty fixture-backed lists", () => {
+        resetDemoFixturesCache();
+
+        expect(getDemoQueues(1, 10).total).toBeGreaterThan(0);
+        expect(getDemoJobs(1, 10).total).toBeGreaterThan(0);
+        expect(getDemoPods(1, 10).total).toBeGreaterThan(0);
+        expect(getDemoPodGroups(1, 10).total).toBeGreaterThan(0);
+    });
+
+    it("paginates fixture data", () => {
+        resetDemoFixturesCache();
+
+        const page1 = getDemoQueues(1, 2);
+        const page2 = getDemoQueues(2, 2);
+
+        expect(page1.items).toHaveLength(2);
+        expect(page1.page).toBe(1);
+        expect(page2.page).toBe(2);
+        expect(page1.total).toBeGreaterThan(page1.items.length);
+    });
+
+    it("derives dashboard summary metrics from fixtures", () => {
+        resetDemoFixturesCache();
+
+        const summary = getDemoSummary();
+
+        expect(summary.totalJobs).toBeGreaterThan(0);
+        expect(summary.runningPods).toBeGreaterThan(0);
+        expect(summary.completeRate).toMatch(/%$/);
+    });
+
+    it("blocks write operations in demo mode", () => {
+        expect(() => assertDemoWritable()).toThrow(TRPCError);
+    });
+});

--- a/packages/trpc/server/demo/handlers.ts
+++ b/packages/trpc/server/demo/handlers.ts
@@ -1,0 +1,251 @@
+import yaml from "js-yaml";
+import { getJobState } from "../router/helpers";
+import { buildPaginatedResponse } from "../router/pagination";
+import { loadDemoFixtures } from "./fixtures";
+
+type PodGroupFilters = {
+    namespace?: string;
+    search?: string;
+    status?: string;
+};
+
+function paginate<T>(items: T[], page: number, pageSize: number) {
+    const total = items.length;
+    const start = (page - 1) * pageSize;
+    const slice = items.slice(start, start + pageSize);
+    return buildPaginatedResponse(slice, page, pageSize, total);
+}
+
+function toYaml(data: unknown): string {
+    return yaml.dump(data, {
+        indent: 2,
+        lineWidth: -1,
+        noRefs: true,
+        sortKeys: false,
+    });
+}
+
+export function getDemoSummary() {
+    const { jobs, pods } = loadDemoFixtures();
+    const activeJobs = jobs.filter((job) => {
+        const state =
+            (job.status?.state as { phase?: string } | undefined)?.phase ||
+            getJobState(job as Parameters<typeof getJobState>[0]);
+        return ["Running", "Pending", "Inqueue"].includes(String(state));
+    }).length;
+    const runningPods = pods.filter(
+        (pod) => (pod.status?.phase as string | undefined) === "Running",
+    ).length;
+    const totalJobs = jobs.length;
+    const completeRate =
+        totalJobs > 0
+            ? `${Math.round(((totalJobs - activeJobs) / totalJobs) * 100)}%`
+            : "0%";
+
+    return {
+        totalJobs,
+        activeJobs,
+        runningPods,
+        completeRate,
+    };
+}
+
+export function getDemoJobStatusMetrics() {
+    const { jobs } = loadDemoFixtures();
+    const statusCounts: Record<string, number> = {};
+
+    for (const job of jobs) {
+        const state =
+            (job.status?.state as { phase?: string } | undefined)?.phase ||
+            getJobState(job as Parameters<typeof getJobState>[0]);
+        statusCounts[String(state)] = (statusCounts[String(state)] || 0) + 1;
+    }
+
+    return Object.entries(statusCounts).map(([name, value]) => ({
+        name,
+        value,
+    }));
+}
+
+export function getDemoQueueMetrics() {
+    const { queues } = loadDemoFixtures();
+
+    return queues.map((queue) => {
+        const spec = queue.spec || {};
+        const status = queue.status || {};
+        const allocated = (status.allocated as Record<string, unknown>) || {};
+        const capability = (spec.capability as Record<string, unknown>) || {};
+        const runningPods =
+            Number(status.running ?? 0) +
+            Number(status.pending ?? 0) +
+            Number(status.inqueue ?? 0);
+
+        return {
+            name: queue.metadata?.name || "Unknown",
+            weight: Number(spec.weight ?? 0),
+            reclaimable: Boolean(spec.reclaimable ?? status.reclaimable ?? false),
+            cpu: allocated.cpu != null ? String(allocated.cpu) : "0",
+            memory: allocated.memory != null ? String(allocated.memory) : "0",
+            pods:
+                allocated.pods != null ? String(allocated.pods) : String(runningPods),
+            cpuCapability:
+                capability.cpu != null ? String(capability.cpu) : "0",
+            memoryCapability:
+                capability.memory != null ? String(capability.memory) : "0",
+            podsCapability:
+                capability.pods != null ? String(capability.pods) : "0",
+        };
+    });
+}
+
+export function getDemoQueues(page: number, pageSize: number) {
+    const { queues } = loadDemoFixtures();
+    return paginate(queues, page, pageSize);
+}
+
+export function getDemoQueue(name: string) {
+    const { queues } = loadDemoFixtures();
+    const queue = queues.find((item) => item.metadata?.name === name);
+    if (!queue) {
+        throw new Error(`Queue ${name} not found`);
+    }
+    return queue;
+}
+
+export function getDemoQueueYaml(name: string) {
+    return toYaml(getDemoQueue(name));
+}
+
+export function getDemoAllQueues() {
+    const { queues } = loadDemoFixtures();
+    return {
+        items: queues,
+        totalCount: queues.length,
+    };
+}
+
+export function getDemoJobs(page: number, pageSize: number) {
+    const { jobs } = loadDemoFixtures();
+    return paginate(jobs, page, pageSize);
+}
+
+export function getDemoJob(namespace: string, name: string) {
+    const { jobs } = loadDemoFixtures();
+    const job = jobs.find(
+        (item) =>
+            item.metadata?.name === name &&
+            item.metadata?.namespace === namespace,
+    );
+    if (!job) {
+        throw new Error(`Job ${namespace}/${name} not found`);
+    }
+    return job;
+}
+
+export function getDemoJobYaml(namespace: string, name: string) {
+    return toYaml(getDemoJob(namespace, name));
+}
+
+export function getDemoAllJobs() {
+    const { jobs } = loadDemoFixtures();
+    return {
+        items: jobs.map((job) => ({
+            ...job,
+            status: {
+                state:
+                    job.status?.state ||
+                    getJobState(job as Parameters<typeof getJobState>[0]),
+                phase:
+                    (job.status as { phase?: string } | undefined)?.phase ||
+                    "Unknown",
+            },
+        })),
+        totalCount: jobs.length,
+    };
+}
+
+export function getDemoPods(page: number, pageSize: number) {
+    const { pods } = loadDemoFixtures();
+    const activePods = pods.filter((pod) => !pod.metadata?.deletionTimestamp);
+    return paginate(activePods, page, pageSize);
+}
+
+export function getDemoPod(namespace: string, name: string) {
+    const { pods } = loadDemoFixtures();
+    const pod = pods.find(
+        (item) =>
+            item.metadata?.name === name &&
+            item.metadata?.namespace === namespace,
+    );
+    if (!pod) {
+        throw new Error(`Pod ${namespace}/${name} not found`);
+    }
+    return pod;
+}
+
+export function getDemoPodYaml(namespace: string, name: string) {
+    return toYaml(getDemoPod(namespace, name));
+}
+
+export function getDemoAllPods() {
+    const { pods } = loadDemoFixtures();
+    const defaultPods = pods.filter(
+        (pod) => pod.metadata?.namespace === "default",
+    );
+    return {
+        items: defaultPods,
+        totalCount: defaultPods.length,
+    };
+}
+
+export function getDemoPodGroups(
+    page: number,
+    pageSize: number,
+    filters: PodGroupFilters = {},
+) {
+    const { podgroups } = loadDemoFixtures();
+    const namespace = filters.namespace?.trim() ?? "";
+    const search = filters.search?.trim().toLowerCase() ?? "";
+    const status = filters.status?.trim() ?? "";
+
+    const filtered = podgroups.filter((pg) => {
+        if (pg.metadata?.deletionTimestamp) {
+            return false;
+        }
+        if (namespace && namespace !== "All") {
+            if (pg.metadata?.namespace !== namespace) {
+                return false;
+            }
+        }
+        if (search) {
+            if (!String(pg.metadata?.name ?? "").toLowerCase().includes(search)) {
+                return false;
+            }
+        }
+        if (status && status !== "All") {
+            if ((pg.status?.phase as string | undefined) !== status) {
+                return false;
+            }
+        }
+        return true;
+    });
+
+    return paginate(filtered, page, pageSize);
+}
+
+export function getDemoPodGroup(namespace: string, name: string) {
+    const { podgroups } = loadDemoFixtures();
+    const podgroup = podgroups.find(
+        (item) =>
+            item.metadata?.name === name &&
+            item.metadata?.namespace === namespace,
+    );
+    if (!podgroup) {
+        throw new Error(`PodGroup ${namespace}/${name} not found`);
+    }
+    return podgroup;
+}
+
+export function getDemoPodGroupYaml(namespace: string, name: string) {
+    return toYaml(getDemoPodGroup(namespace, name));
+}

--- a/packages/trpc/server/demo/test-setup.ts
+++ b/packages/trpc/server/demo/test-setup.ts
@@ -1,0 +1,8 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(packageDir, "../../../..");
+
+process.chdir(repoRoot);
+process.env.DASHBOARD_DEMO_MODE = "true";

--- a/packages/trpc/server/router/dashboard/dashboard.ts
+++ b/packages/trpc/server/router/dashboard/dashboard.ts
@@ -1,5 +1,7 @@
 
 import { procedure, router } from "../../trpc";
+import * as demoHandlers from "../../demo/handlers";
+import { isDemoMode } from "../../utils/demo";
 import { k8sApi, k8sCoreApi } from "../../utils/k8s";
 
 // Helper function to get summary statistics
@@ -129,14 +131,23 @@ const getQueueResourcesMetrics = async () => {
 
 export const dashboardRouter = router({
     getSummary: procedure.query(async () => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoSummary();
+        }
         const summary = await getSummary();
         return summary;
     }),
     getJobStatusMetrics: procedure.query(async () => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoJobStatusMetrics();
+        }
         const jobStatusMetrics = await getJobStatusMetrics();
         return jobStatusMetrics;
     }),
     getQueueMetrics: procedure.query(async () => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoQueueMetrics();
+        }
         const queueResourcesMetrics = await getQueueResourcesMetrics();
         return queueResourcesMetrics;
     }),

--- a/packages/trpc/server/router/helpers.ts
+++ b/packages/trpc/server/router/helpers.ts
@@ -1,4 +1,6 @@
 import { k8sApi, k8sCoreApi } from "../utils/k8s";
+import { isDemoMode } from "../utils/demo";
+import * as demoHandlers from "../demo/handlers";
 import { buildPaginatedResponse, type PaginatedResponse } from "./pagination";
 
 const LIST_CHUNK_LIMIT = 250;
@@ -109,6 +111,9 @@ export const fetchJobs = async (
     page: number,
     pageSize: number,
 ): Promise<PaginatedResponse<unknown>> => {
+    if (isDemoMode()) {
+        return demoHandlers.getDemoJobs(page, pageSize);
+    }
     return fetchPaginatedK8sList(
         page,
         pageSize,
@@ -157,6 +162,9 @@ export const fetchQueues = async (
     page: number,
     pageSize: number,
 ): Promise<PaginatedResponse<unknown>> => {
+    if (isDemoMode()) {
+        return demoHandlers.getDemoQueues(page, pageSize);
+    }
     return fetchPaginatedK8sList(
         page,
         pageSize,
@@ -179,6 +187,9 @@ export const fetchPods = async (
     page: number,
     pageSize: number,
 ): Promise<PaginatedResponse<unknown>> => {
+    if (isDemoMode()) {
+        return demoHandlers.getDemoPods(page, pageSize);
+    }
     return fetchPaginatedK8sList(
         page,
         pageSize,
@@ -210,6 +221,9 @@ export const fetchPodGroups = async (
         status?: string;
     } = {},
 ): Promise<PaginatedResponse<unknown>> => {
+    if (isDemoMode()) {
+        return demoHandlers.getDemoPodGroups(page, pageSize, filters);
+    }
     const namespace = filters.namespace?.trim() ?? "";
     const search = filters.search?.trim().toLowerCase() ?? "";
     const status = filters.status?.trim() ?? "";

--- a/packages/trpc/server/router/jobs/jobs.ts
+++ b/packages/trpc/server/router/jobs/jobs.ts
@@ -1,5 +1,7 @@
 import yaml from "js-yaml";
 import { procedure, router } from "../../trpc";
+import * as demoHandlers from "../../demo/handlers";
+import { assertDemoWritable, isDemoMode } from "../../utils/demo";
 import { formatK8sApiError } from "../../utils/k8s-errors";
 import { validateJobManifest } from "../../utils/job-validation";
 import { k8sApi } from "../../utils/k8s";
@@ -18,6 +20,9 @@ export const jobsRouter = router({
             page = 1,
             pageSize = 10,
         } = input;
+        if (isDemoMode()) {
+            return demoHandlers.getDemoJobs(page, pageSize);
+        }
         console.log("Fetching jobs with params:", {
             page,
             pageSize,
@@ -26,6 +31,9 @@ export const jobsRouter = router({
         return fetchJobs(page, pageSize);
     }),
     getJob: procedure.input(getJobInputSchema).query(async ({ input }) => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoJob(input.namespace, input.name);
+        }
         const { namespace, name } = input;
         const response = await k8sApi.getNamespacedCustomObject({
             group: "batch.volcano.sh",
@@ -37,6 +45,9 @@ export const jobsRouter = router({
         return response;
     }),
     getJobYaml: procedure.input(getJobInputSchema).query(async ({ input }) => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoJobYaml(input.namespace, input.name);
+        }
         const { namespace, name } = input;
         const response = await k8sApi.getNamespacedCustomObject({
             group: "batch.volcano.sh",
@@ -56,6 +67,9 @@ export const jobsRouter = router({
         return formattedYaml;
     }),
     getAllJobs: procedure.query(async () => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoAllJobs();
+        }
         const response = await k8sApi.listClusterCustomObject({
             group: "batch.volcano.sh",
             version: "v1alpha1",
@@ -81,6 +95,7 @@ export const jobsRouter = router({
         };
     }),
     createJob: procedure.input(createJobInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { jobManifest } = input;
 
         if (!jobManifest.metadata.name || !jobManifest.spec) {
@@ -112,6 +127,7 @@ export const jobsRouter = router({
         }
     }),
     updateJob: procedure.input(updateJobInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { namespace, name, patchData } = input;
 
         const currentJob = await k8sApi.getNamespacedCustomObject({
@@ -149,6 +165,7 @@ export const jobsRouter = router({
         };
     }),
     deleteJob: procedure.input(deleteJobInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { namespace, name } = input;
 
         const response = await k8sApi.deleteNamespacedCustomObject({

--- a/packages/trpc/server/router/podgroups/podgroups.ts
+++ b/packages/trpc/server/router/podgroups/podgroups.ts
@@ -1,5 +1,7 @@
 import yaml from "js-yaml";
 import { procedure, router } from "../../trpc";
+import * as demoHandlers from "../../demo/handlers";
+import { isDemoMode } from "../../utils/demo";
 import { k8sApi } from "../../utils/k8s";
 import { fetchPodGroups } from "../helpers";
 import { getPodGroupsInputSchema, getPodGroupInputSchema, getPodGroupYamlInputSchema } from "./schema";
@@ -14,10 +16,21 @@ export const podgroupsRouter = router({
             pageSize = 10,
         } = input;
 
+        if (isDemoMode()) {
+            return demoHandlers.getDemoPodGroups(page, pageSize, {
+                namespace,
+                search,
+                status,
+            });
+        }
+
         return fetchPodGroups(page, pageSize, { namespace, search, status });
     }),
 
     getPodGroup: procedure.input(getPodGroupInputSchema).query(async ({ input }) => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoPodGroup(input.namespace, input.name);
+        }
         const { namespace, name } = input;
         const response = await k8sApi.getNamespacedCustomObject({
             group: "scheduling.volcano.sh",
@@ -32,6 +45,12 @@ export const podgroupsRouter = router({
     getPodGroupYaml: procedure
         .input(getPodGroupYamlInputSchema)
         .query(async ({ input }) => {
+            if (isDemoMode()) {
+                return demoHandlers.getDemoPodGroupYaml(
+                    input.namespace,
+                    input.name,
+                );
+            }
             const { namespace, name } = input;
             const response = await k8sApi.getNamespacedCustomObject({
                 group: "scheduling.volcano.sh",

--- a/packages/trpc/server/router/pods/pods.ts
+++ b/packages/trpc/server/router/pods/pods.ts
@@ -1,5 +1,7 @@
 import yaml from "js-yaml";
 import { procedure, router } from "../../trpc";
+import * as demoHandlers from "../../demo/handlers";
+import { assertDemoWritable, isDemoMode } from "../../utils/demo";
 import { k8sCoreApi } from "../../utils/k8s";
 import { fetchPods } from "../helpers";
 import { createPodInputSchema, deletePodInputSchema, getPodsInputSchema, getPodYamlInputSchema, updatePodInputSchema } from "./schema";
@@ -10,6 +12,9 @@ export const podRouter = router({
             page = 1,
             pageSize = 10,
         } = input;
+        if (isDemoMode()) {
+            return demoHandlers.getDemoPods(page, pageSize);
+        }
         console.log("Fetching pods with params:", {
             page,
             pageSize,
@@ -20,6 +25,9 @@ export const podRouter = router({
     getPodYaml: procedure
         .input(getPodYamlInputSchema)
         .query(async ({ input }) => {
+            if (isDemoMode()) {
+                return demoHandlers.getDemoPodYaml(input.namespace, input.name);
+            }
             const { namespace, name } = input;
             const response = await k8sCoreApi.readNamespacedPod({
                 name,
@@ -36,6 +44,9 @@ export const podRouter = router({
             return formattedYaml;
         }),
     getAllPods: procedure.query(async () => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoAllPods();
+        }
         const response = await k8sCoreApi.listNamespacedPod({
             namespace: "default",
         });
@@ -45,6 +56,7 @@ export const podRouter = router({
         };
     }),
     createPod: procedure.input(createPodInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { podManifest } = input;
 
         const response = await k8sCoreApi.createNamespacedPod({
@@ -58,6 +70,7 @@ export const podRouter = router({
         };
     }),
     updatePod: procedure.input(updatePodInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { namespace, name, patchData } = input;
 
         // First, get the current pod to preserve metadata like resourceVersion
@@ -123,6 +136,7 @@ export const podRouter = router({
         };
     }),
     deletePod: procedure.input(deletePodInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { namespace, name } = input;
 
         const response = await k8sCoreApi.deleteNamespacedPod({

--- a/packages/trpc/server/router/queues/queues.ts
+++ b/packages/trpc/server/router/queues/queues.ts
@@ -1,5 +1,7 @@
 import yaml from "js-yaml";
 import { procedure, router } from "../../trpc";
+import * as demoHandlers from "../../demo/handlers";
+import { assertDemoWritable, isDemoMode } from "../../utils/demo";
 import { formatK8sApiError } from "../../utils/k8s-errors";
 import { k8sApi } from "../../utils/k8s";
 import { isProtectedQueue, protectedQueueDeleteMessage } from "../../utils/queue-constants";
@@ -15,6 +17,9 @@ import {
 
 export const queueRouter = router({
     getQueue: procedure.input(getQueueInputSchema).query(async ({ input }) => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoQueue(input.name);
+        }
         const { name } = input;
         const response = await k8sApi.getClusterCustomObject({
             group: "scheduling.volcano.sh",
@@ -27,6 +32,9 @@ export const queueRouter = router({
     getQueueYaml: procedure
         .input(getQueueInputSchema)
         .query(async ({ input }) => {
+            if (isDemoMode()) {
+                return demoHandlers.getDemoQueueYaml(input.name);
+            }
             const { name } = input;
             const response = await k8sApi.getClusterCustomObject({
                 group: "scheduling.volcano.sh",
@@ -48,6 +56,9 @@ export const queueRouter = router({
         .input(getQueuesInputSchema)
         .query(async ({ input }) => {
             const { page = 1, pageSize = 10 } = input;
+            if (isDemoMode()) {
+                return demoHandlers.getDemoQueues(page, pageSize);
+            }
             console.log("Fetching queues with params:", {
                 page,
                 pageSize,
@@ -56,6 +67,9 @@ export const queueRouter = router({
             return fetchQueues(page, pageSize);
         }),
     getAllQueues: procedure.query(async () => {
+        if (isDemoMode()) {
+            return demoHandlers.getDemoAllQueues();
+        }
         const response = await k8sApi.listClusterCustomObject({
             group: "scheduling.volcano.sh",
             version: "v1beta1",
@@ -67,6 +81,7 @@ export const queueRouter = router({
         };
     }),
     createQueue: procedure.input(createQueueInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { queueManifest } = input;
 
         if (!queueManifest.metadata.name || !queueManifest.spec) {
@@ -97,6 +112,7 @@ export const queueRouter = router({
         }
     }),
     updateQueue: procedure.input(updateQueueInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { name, updatedBody } = input;
 
         if (!updatedBody.spec || Object.keys(updatedBody.spec).length === 0) {
@@ -172,6 +188,7 @@ export const queueRouter = router({
         }
     }),
     deleteQueue: procedure.input(deleteQueueInputSchema).mutation(async ({ input }) => {
+        assertDemoWritable();
         const { name } = input;
         const queueName = name.toLowerCase();
 

--- a/packages/trpc/server/utils/demo.ts
+++ b/packages/trpc/server/utils/demo.ts
@@ -1,0 +1,15 @@
+import { TRPCError } from "@trpc/server";
+
+export function isDemoMode(): boolean {
+    return process.env.DASHBOARD_DEMO_MODE === "true";
+}
+
+export function assertDemoWritable(): void {
+    if (isDemoMode()) {
+        throw new TRPCError({
+            code: "FORBIDDEN",
+            message:
+                "Demo mode: create, update, and delete operations are disabled.",
+        });
+    }
+}

--- a/packages/trpc/server/utils/k8s.ts
+++ b/packages/trpc/server/utils/k8s.ts
@@ -1,30 +1,58 @@
 import { CoreV1Api, CustomObjectsApi, KubeConfig } from "@kubernetes/client-node";
+import { isDemoMode } from "./demo";
 
-const kc = new KubeConfig();
+let k8sApiInstance: CustomObjectsApi | null = null;
+let k8sCoreApiInstance: CoreV1Api | null = null;
 
-try {
-    kc.loadFromDefault();
-
-    const skipTLSVerify = process.env.K8S_SKIP_TLS_VERIFY === 'true';
-    const serverOverride = process.env.K8S_SERVER?.trim();
-
-    if (skipTLSVerify || serverOverride) {
-        const clusters = kc.getClusters().map(cluster => ({
-            ...cluster,
-            ...(serverOverride && { server: serverOverride }),
-            ...(skipTLSVerify && { skipTLSVerify: true }),
-        }));
-
-        kc.loadFromOptions({
-            clusters,
-            users: kc.getUsers(),
-            contexts: kc.getContexts(),
-            currentContext: kc.getCurrentContext(),
-        });
+function getClients() {
+    if (k8sApiInstance && k8sCoreApiInstance) {
+        return { k8sApi: k8sApiInstance, k8sCoreApi: k8sCoreApiInstance };
     }
-} catch (error) {
-    console.warn('Warning: Could not load Kubernetes config:', error);
+
+    if (isDemoMode()) {
+        throw new Error("Kubernetes clients are unavailable in demo mode.");
+    }
+
+    const kc = new KubeConfig();
+
+    try {
+        kc.loadFromDefault();
+
+        const skipTLSVerify = process.env.K8S_SKIP_TLS_VERIFY === "true";
+        const serverOverride = process.env.K8S_SERVER?.trim();
+
+        if (skipTLSVerify || serverOverride) {
+            const clusters = kc.getClusters().map((cluster) => ({
+                ...cluster,
+                ...(serverOverride && { server: serverOverride }),
+                ...(skipTLSVerify && { skipTLSVerify: true }),
+            }));
+
+            kc.loadFromOptions({
+                clusters,
+                users: kc.getUsers(),
+                contexts: kc.getContexts(),
+                currentContext: kc.getCurrentContext(),
+            });
+        }
+    } catch (error) {
+        console.warn("Warning: Could not load Kubernetes config:", error);
+    }
+
+    k8sApiInstance = kc.makeApiClient(CustomObjectsApi);
+    k8sCoreApiInstance = kc.makeApiClient(CoreV1Api);
+
+    return { k8sApi: k8sApiInstance, k8sCoreApi: k8sCoreApiInstance };
 }
 
-export const k8sApi = kc.makeApiClient(CustomObjectsApi);
-export const k8sCoreApi = kc.makeApiClient(CoreV1Api);
+export const k8sApi = new Proxy({} as CustomObjectsApi, {
+    get(_target, prop, receiver) {
+        return Reflect.get(getClients().k8sApi, prop, receiver);
+    },
+});
+
+export const k8sCoreApi = new Proxy({} as CoreV1Api, {
+    get(_target, prop, receiver) {
+        return Reflect.get(getClients().k8sCoreApi, prop, receiver);
+    },
+});

--- a/packages/trpc/server/utils/k8s.ts
+++ b/packages/trpc/server/utils/k8s.ts
@@ -46,13 +46,17 @@ function getClients() {
 }
 
 export const k8sApi = new Proxy({} as CustomObjectsApi, {
-    get(_target, prop, receiver) {
-        return Reflect.get(getClients().k8sApi, prop, receiver);
+    get(_target, prop) {
+        const client = getClients().k8sApi;
+        const value = Reflect.get(client, prop);
+        return typeof value === "function" ? value.bind(client) : value;
     },
 });
 
 export const k8sCoreApi = new Proxy({} as CoreV1Api, {
-    get(_target, prop, receiver) {
-        return Reflect.get(getClients().k8sCoreApi, prop, receiver);
+    get(_target, prop) {
+        const client = getClients().k8sCoreApi;
+        const value = Reflect.get(client, prop);
+        return typeof value === "function" ? value.bind(client) : value;
     },
 });

--- a/packages/trpc/vitest.config.ts
+++ b/packages/trpc/vitest.config.ts
@@ -1,0 +1,13 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import { defineConfig } from "vitest/config";
+
+const packageDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(packageDir, "../..");
+
+export default defineConfig({
+    test: {
+        environment: "node",
+        setupFiles: [path.join(packageDir, "server/demo/test-setup.ts")],
+    },
+});

--- a/turbo.json
+++ b/turbo.json
@@ -18,7 +18,9 @@
         "PORT",
         "NODE_ENV",
         "K8S_SKIP_TLS_VERIFY",
-        "K8S_SERVER"
+        "K8S_SERVER",
+        "DASHBOARD_DEMO_MODE",
+        "NEXT_PUBLIC_DASHBOARD_DEMO_MODE"
       ]
     },
     "lint": {
@@ -29,7 +31,9 @@
         "PORT",
         "NODE_ENV",
         "K8S_SKIP_TLS_VERIFY",
-        "K8S_SERVER"
+        "K8S_SERVER",
+        "DASHBOARD_DEMO_MODE",
+        "NEXT_PUBLIC_DASHBOARD_DEMO_MODE"
       ]
     },
     "check-types": {
@@ -40,7 +44,9 @@
         "PORT",
         "NODE_ENV",
         "K8S_SKIP_TLS_VERIFY",
-        "K8S_SERVER"
+        "K8S_SERVER",
+        "DASHBOARD_DEMO_MODE",
+        "NEXT_PUBLIC_DASHBOARD_DEMO_MODE"
       ]
     },
     "dev": {
@@ -50,7 +56,9 @@
         "PORT",
         "NODE_ENV",
         "K8S_SKIP_TLS_VERIFY",
-        "K8S_SERVER"
+        "K8S_SERVER",
+        "DASHBOARD_DEMO_MODE",
+        "NEXT_PUBLIC_DASHBOARD_DEMO_MODE"
       ]
     }
   }


### PR DESCRIPTION
## Summary

Adds the hybrid deploy-preview flow for the Volcano dashboard:

- **Netlify PR previews** run with `DASHBOARD_DEMO_MODE=true` so reviewers get a populated, read-only UI without a Kubernetes cluster.
- **Kind integration CI** deploys the real dashboard image into a Kind cluster with Volcano and `examples/cluster-samples/`, then runs home-page and tRPC smoke tests.

Both paths share the same fixture source: `examples/cluster-samples/`.

## Changes

- Add `examples/cluster-samples/` (namespaces, queues, podgroups, pods, jobs)
- Add demo mode in `packages/trpc` (fixture loader, handlers, router wiring, lazy K8s client)
- Add demo banner + hide create/edit/delete actions in `apps/web`
- Add `netlify.toml` with demo env vars
- Add/enhance `hack/run-e2e-kind.sh` and `hack/smoke-test-dashboard.sh`
- Add `.github/workflows/e2e-kind.yml` (Kind job + Netlify build + PR comment)
- Add demo handler unit tests in `packages/trpc`

## How to review

| Check | What it validates |
|-------|-------------------|
| Netlify deploy preview | UI with demo fixtures (read-only) |
| Dashboard on Kind | Real Volcano + dashboard deploy + API smoke tests |

## Setup required (maintainers)

To enable Netlify deploy previews on PRs:

1. Connect the repo to Netlify (or use the Netlify GitHub App)
2. Add secrets: `NETLIFY_AUTH_TOKEN`, `NETLIFY_SITE_ID`
3. Set repo variable: `ENABLE_NETLIFY_PREVIEW=true`

Without those, the Kind job still runs; only the Netlify deploy + PR comment are skipped.

## Test plan

- [ ] `DASHBOARD_DEMO_MODE=true NEXT_PUBLIC_DASHBOARD_DEMO_MODE=true npm run dev` — pages load with demo data, no cluster
- [ ] Create/edit/delete controls are hidden in demo mode
- [ ] `npm run build` passes with demo env vars
- [ ] `cd packages/trpc && npm test`
- [ ] `bash hack/run-e2e-kind.sh` (Docker + Kind required)
- [ ] Netlify preview shows banner + populated UI (after secrets are configured)