### PR TITLE
fix(pods): correctly display sub-day pod age instead of hardcoded "1d"

### DIFF
--- a/apps/web/src/components/(dashboard)/pods/pod-management.tsx
+++ b/apps/web/src/components/(dashboard)/pods/pod-management.tsx
@@ -162,7 +162,14 @@ export default function PodManagement() {
                     const now = new Date();
                     const ageInMs = now.getTime() - createdAt.getTime();
                     const ageInDays = Math.floor(ageInMs / (1000 * 60 * 60 * 24));
-                    const age = ageInDays === 0 ? "1d" : `${ageInDays}d`;
+                    const ageInHours = Math.floor(ageInMs / (1000 * 60 * 60));
+                    const ageInMinutes = Math.floor(ageInMs / (1000 * 60));
+                    const age =
+                        ageInDays > 0
+                            ? `${ageInDays}d`
+                            : ageInHours > 0
+                                ? `${ageInHours}h`
+                                : `${Math.max(1, ageInMinutes)}m`;
 
                     return {
                         name: pod.metadata?.name || '',


### PR DESCRIPTION
Fixes #327

## What

Pods younger than 24 hours were always shown with an age of `1d`, regardless of whether they were 1 second or 23 hours old, because `ageInDays === 0` was explicitly special-cased to the string `"1d"` instead of being formatted as a proper sub-day value.

## Before

```tsx
const age = ageInDays === 0 ? "1d" : `${ageInDays}d`;
```

## After

```tsx
const ageInHours = Math.floor(ageInMs / (1000 * 60 * 60));
const ageInMinutes = Math.floor(ageInMs / (1000 * 60));
const age =
    ageInDays > 0
        ? `${ageInDays}d`
        : ageInHours > 0
            ? `${ageInHours}h`
            : `${Math.max(1, ageInMinutes)}m`;
```

Now falls back to hours or minutes (minimum `1m`) when the pod is less than a day old, instead of lying about the age.

## Why it matters

This was most misleading exactly when it mattered most: diagnosing a freshly created or crash-looping pod. It was also internally inconsistent with the `Created:` timestamp shown right next to it in the Pod Details modal.

## Scope

Minimal, targeted fix — only touches the age-formatting logic in `apps/web/src/components/(dashboard)/pods/pod-management.tsx`. No new dependencies, no unrelated refactors.
