### PR TITLE
fix(queues): use JSON-Patch "add" instead of "replace" for queue spec updates

### DIFF
--- a/packages/trpc/server/router/queues/queues.ts
+++ b/packages/trpc/server/router/queues/queues.ts
@@ -140,7 +140,7 @@ export const queueRouter = router({
             }
 
             patchOperations.push({
-                op: "replace",
+                op: "add",
                 path: `/spec/${key}`,
                 value: val,
             });


### PR DESCRIPTION
Fixes #330

Small one-liner, so I'll keep it short. `updateQueue` was building its patch with `op: "replace"` for every field, but `replace` needs the path to already be there — so setting capability/guarantee/deserved for the first time on an existing queue always failed with a "doc is missing path" error from Kubernetes.

Switched it to `op: "add"`, which handles both cases (creates the key if it's missing, overwrites it if it's already there), so no need to special-case which fields are new vs. existing.

Didn't touch anything else in this file. Couldn't run `npm run format` locally since deps aren't installed in my environment — let me know if CI flags anything there.
