### PR TITLE
fix: wrap remaining Pod/Job/Queue mutations in formatK8sApiError

### DIFF
--- a/packages/trpc/server/router/jobs/jobs.ts
+++ b/packages/trpc/server/router/jobs/jobs.ts
@@ -114,55 +114,63 @@ export const jobsRouter = router({
     updateJob: procedure.input(updateJobInputSchema).mutation(async ({ input }) => {
         const { namespace, name, patchData } = input;
 
-        const currentJob = await k8sApi.getNamespacedCustomObject({
-            group: "batch.volcano.sh",
-            version: "v1alpha1",
-            namespace,
-            plural: "jobs",
-            name,
-        });
+        try {
+            const currentJob = await k8sApi.getNamespacedCustomObject({
+                group: "batch.volcano.sh",
+                version: "v1alpha1",
+                namespace,
+                plural: "jobs",
+                name,
+            });
 
-        const updatedJob = {
-            ...currentJob,
-            ...patchData,
-            metadata: {
-                ...(currentJob as any).metadata,
-                ...patchData.metadata,
-                resourceVersion: (currentJob as any).metadata?.resourceVersion,
-                uid: (currentJob as any).metadata?.uid,
-                creationTimestamp: (currentJob as any).metadata?.creationTimestamp,
-            },
-        };
+            const updatedJob = {
+                ...currentJob,
+                ...patchData,
+                metadata: {
+                    ...(currentJob as any).metadata,
+                    ...patchData.metadata,
+                    resourceVersion: (currentJob as any).metadata?.resourceVersion,
+                    uid: (currentJob as any).metadata?.uid,
+                    creationTimestamp: (currentJob as any).metadata?.creationTimestamp,
+                },
+            };
 
-        const response = await k8sApi.replaceNamespacedCustomObject({
-            group: "batch.volcano.sh",
-            version: "v1alpha1",
-            namespace,
-            plural: "jobs",
-            name,
-            body: updatedJob,
-        });
+            const response = await k8sApi.replaceNamespacedCustomObject({
+                group: "batch.volcano.sh",
+                version: "v1alpha1",
+                namespace,
+                plural: "jobs",
+                name,
+                body: updatedJob,
+            });
 
-        return {
-            message: "Job updated successfully",
-            data: response.body,
-        };
+            return {
+                message: "Job updated successfully",
+                data: response.body,
+            };
+        } catch (error) {
+            throw new Error(formatK8sApiError(error));
+        }
     }),
     deleteJob: procedure.input(deleteJobInputSchema).mutation(async ({ input }) => {
         const { namespace, name } = input;
 
-        const response = await k8sApi.deleteNamespacedCustomObject({
-            group: "batch.volcano.sh",
-            version: "v1alpha1",
-            namespace,
-            plural: "jobs",
-            name,
-            body: { propagationPolicy: "Foreground" },
-        });
+        try {
+            const response = await k8sApi.deleteNamespacedCustomObject({
+                group: "batch.volcano.sh",
+                version: "v1alpha1",
+                namespace,
+                plural: "jobs",
+                name,
+                body: { propagationPolicy: "Foreground" },
+            });
 
-        return {
-            message: "Job deleted successfully",
-            data: response.body,
-        };
+            return {
+                message: "Job deleted successfully",
+                data: response.body,
+            };
+        } catch (error) {
+            throw new Error(formatK8sApiError(error));
+        }
     }),
 });

--- a/packages/trpc/server/router/pods/pods.ts
+++ b/packages/trpc/server/router/pods/pods.ts
@@ -1,6 +1,7 @@
 import yaml from "js-yaml";
 import { procedure, router } from "../../trpc";
 import { k8sCoreApi } from "../../utils/k8s";
+import { formatK8sApiError } from "../../utils/k8s-errors";
 import { fetchPods } from "../helpers";
 import { createPodInputSchema, deletePodInputSchema, getPodsInputSchema, getPodYamlInputSchema, updatePodInputSchema } from "./schema";
 
@@ -47,92 +48,104 @@ export const podRouter = router({
     createPod: procedure.input(createPodInputSchema).mutation(async ({ input }) => {
         const { podManifest } = input;
 
-        const response = await k8sCoreApi.createNamespacedPod({
-            namespace: podManifest.metadata.namespace || "default",
-            body: podManifest,
-        });
+        try {
+            const response = await k8sCoreApi.createNamespacedPod({
+                namespace: podManifest.metadata.namespace || "default",
+                body: podManifest,
+            });
 
-        return {
-            message: "Pod created successfully",
-            data: response,
-        };
+            return {
+                message: "Pod created successfully",
+                data: response,
+            };
+        } catch (error) {
+            throw new Error(formatK8sApiError(error));
+        }
     }),
     updatePod: procedure.input(updatePodInputSchema).mutation(async ({ input }) => {
         const { namespace, name, patchData } = input;
 
-        // First, get the current pod to preserve metadata like resourceVersion
-        const currentPod = await k8sCoreApi.readNamespacedPod({
-            name,
-            namespace,
-        });
-
-        // For pods, we can only update specific fields per Kubernetes restrictions
-        // Extract only the allowed changes from patchData
-        const updatedSpec: any = {
-            ...currentPod.spec,
-        };
-
-        // Update container images and imagePullPolicy if provided
-        if (patchData.spec?.containers) {
-            updatedSpec.containers = currentPod.spec?.containers?.map((container: any, index: number) => {
-                const patchContainer = patchData.spec.containers[index];
-                if (!patchContainer) return container;
-
-                return {
-                    ...container,
-                    ...(patchContainer.image && { image: patchContainer.image }),
-                    ...(patchContainer.imagePullPolicy && { imagePullPolicy: patchContainer.imagePullPolicy }),
-                };
+        try {
+            // First, get the current pod to preserve metadata like resourceVersion
+            const currentPod = await k8sCoreApi.readNamespacedPod({
+                name,
+                namespace,
             });
-        }
 
-        if (patchData.spec?.initContainers && currentPod.spec?.initContainers) {
-            updatedSpec.initContainers = currentPod.spec.initContainers.map((container: any, index: number) => {
-                const patchContainer = patchData.spec.initContainers?.[index];
-                return patchContainer?.image ? { ...container, image: patchContainer.image } : container;
+            // For pods, we can only update specific fields per Kubernetes restrictions
+            // Extract only the allowed changes from patchData
+            const updatedSpec: any = {
+                ...currentPod.spec,
+            };
+
+            // Update container images and imagePullPolicy if provided
+            if (patchData.spec?.containers) {
+                updatedSpec.containers = currentPod.spec?.containers?.map((container: any, index: number) => {
+                    const patchContainer = patchData.spec.containers[index];
+                    if (!patchContainer) return container;
+
+                    return {
+                        ...container,
+                        ...(patchContainer.image && { image: patchContainer.image }),
+                        ...(patchContainer.imagePullPolicy && { imagePullPolicy: patchContainer.imagePullPolicy }),
+                    };
+                });
+            }
+
+            if (patchData.spec?.initContainers && currentPod.spec?.initContainers) {
+                updatedSpec.initContainers = currentPod.spec.initContainers.map((container: any, index: number) => {
+                    const patchContainer = patchData.spec.initContainers?.[index];
+                    return patchContainer?.image ? { ...container, image: patchContainer.image } : container;
+                });
+            }
+
+            if (patchData.spec?.activeDeadlineSeconds !== undefined) {
+                updatedSpec.activeDeadlineSeconds = patchData.spec.activeDeadlineSeconds;
+            }
+            if (patchData.spec?.terminationGracePeriodSeconds !== undefined) {
+                updatedSpec.terminationGracePeriodSeconds = patchData.spec.terminationGracePeriodSeconds;
+            }
+
+            const updatedPod = {
+                ...currentPod,
+                metadata: {
+                    ...currentPod.metadata,
+                    resourceVersion: currentPod.metadata?.resourceVersion,
+                    uid: currentPod.metadata?.uid,
+                    creationTimestamp: currentPod.metadata?.creationTimestamp,
+                },
+                spec: updatedSpec,
+            };
+
+            const response = await k8sCoreApi.replaceNamespacedPod({
+                name,
+                namespace,
+                body: updatedPod,
             });
+
+            return {
+                message: "Pod updated successfully",
+                data: response,
+            };
+        } catch (error) {
+            throw new Error(formatK8sApiError(error));
         }
-
-        if (patchData.spec?.activeDeadlineSeconds !== undefined) {
-            updatedSpec.activeDeadlineSeconds = patchData.spec.activeDeadlineSeconds;
-        }
-        if (patchData.spec?.terminationGracePeriodSeconds !== undefined) {
-            updatedSpec.terminationGracePeriodSeconds = patchData.spec.terminationGracePeriodSeconds;
-        }
-
-        const updatedPod = {
-            ...currentPod,
-            metadata: {
-                ...currentPod.metadata,
-                resourceVersion: currentPod.metadata?.resourceVersion,
-                uid: currentPod.metadata?.uid,
-                creationTimestamp: currentPod.metadata?.creationTimestamp,
-            },
-            spec: updatedSpec,
-        };
-
-        const response = await k8sCoreApi.replaceNamespacedPod({
-            name,
-            namespace,
-            body: updatedPod,
-        });
-
-        return {
-            message: "Pod updated successfully",
-            data: response,
-        };
     }),
     deletePod: procedure.input(deletePodInputSchema).mutation(async ({ input }) => {
         const { namespace, name } = input;
 
-        const response = await k8sCoreApi.deleteNamespacedPod({
-            name,
-            namespace,
-        });
+        try {
+            const response = await k8sCoreApi.deleteNamespacedPod({
+                name,
+                namespace,
+            });
 
-        return {
-            message: "Pod deleted successfully",
-            data: response,
-        };
+            return {
+                message: "Pod deleted successfully",
+                data: response,
+            };
+        } catch (error) {
+            throw new Error(formatK8sApiError(error));
+        }
     }),
 });

--- a/packages/trpc/server/router/queues/queues.ts
+++ b/packages/trpc/server/router/queues/queues.ts
@@ -179,24 +179,28 @@ export const queueRouter = router({
             throw new Error(protectedQueueDeleteMessage(queueName));
         }
 
-        await k8sApi.getClusterCustomObject({
-            group: "scheduling.volcano.sh",
-            version: "v1beta1",
-            plural: "queues",
-            name: queueName,
-        });
+        try {
+            await k8sApi.getClusterCustomObject({
+                group: "scheduling.volcano.sh",
+                version: "v1beta1",
+                plural: "queues",
+                name: queueName,
+            });
 
-        const response = await k8sApi.deleteClusterCustomObject({
-            group: "scheduling.volcano.sh",
-            version: "v1beta1",
-            plural: "queues",
-            name: queueName,
-            body: { propagationPolicy: "Foreground" },
-        });
+            const response = await k8sApi.deleteClusterCustomObject({
+                group: "scheduling.volcano.sh",
+                version: "v1beta1",
+                plural: "queues",
+                name: queueName,
+                body: { propagationPolicy: "Foreground" },
+            });
 
-        return {
-            message: "Queue deleted successfully",
-            data: response.body,
-        };
+            return {
+                message: "Queue deleted successfully",
+                data: response.body,
+            };
+        } catch (error) {
+            throw new Error(formatK8sApiError(error));
+        }
     }),
 });


### PR DESCRIPTION
Follow-up to #338 / #264.

#264 added `formatK8sApiError` so raw Kubernetes API errors get turned into something
readable before they reach the UI, but it only landed in createJob, createQueue, and
updateQueue. This applies the same try/catch + formatK8sApiError pattern to the six
mutations that were missed:

- createPod, updatePod, deletePod (packages/trpc/server/router/pods/pods.ts)
- updateJob, deleteJob (packages/trpc/server/router/jobs/jobs.ts)
- deleteQueue (packages/trpc/server/router/queues/queues.ts)

No behavior changes beyond error formatting — same k8s calls, same return shapes, just
wrapped so failures come back readable instead of raw client exceptions.

Closes #338

## Test plan
- [x] `eslint` on the changed files: 0 errors (7 pre-existing `no-explicit-any` warnings, none introduced by this change)
- [ ] Manually create a Pod with a name that already exists and confirm the error message is readable instead of a raw client exception
- [ ] Manually delete a Queue twice in a row and confirm the same