### PR TITLE
fix: validate Job edits the same way Job creates are validated

### DIFF
--- a/apps/web/src/components/(dashboard)/jobs/job-edit-dialog.tsx
+++ b/apps/web/src/components/(dashboard)/jobs/job-edit-dialog.tsx
@@ -18,6 +18,7 @@ import {
 } from "@/components/ui/dialog"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
+import { validateJobManifest } from "@/lib/job-validation"
 import { trpc } from "@volcano/trpc/react"
 
 interface JobEditDialogProps {
@@ -87,6 +88,19 @@ export function JobEditDialog({ open, setOpen, handleRefresh, jobName, jobNamesp
 
             if (!parsed.spec || typeof parsed.spec !== 'object') {
                 throw new Error('Invalid spec: must be an object')
+            }
+
+            if (!parsed.spec.tasks || !Array.isArray(parsed.spec.tasks)) {
+                throw new Error('Job spec must include tasks array')
+            }
+
+            if (parsed.spec.tasks.length === 0) {
+                throw new Error('Job spec must include at least one task')
+            }
+
+            const jobError = validateJobManifest(parsed)
+            if (jobError) {
+                throw new Error(jobError)
             }
 
             return parsed

--- a/packages/trpc/server/router/jobs/jobs.ts
+++ b/packages/trpc/server/router/jobs/jobs.ts
@@ -134,6 +134,11 @@ export const jobsRouter = router({
             },
         };
 
+        const jobError = validateJobManifest(updatedJob as Record<string, unknown>);
+        if (jobError) {
+            throw new Error(jobError);
+        }
+
         const response = await k8sApi.replaceNamespacedCustomObject({
             group: "batch.volcano.sh",
             version: "v1alpha1",


### PR DESCRIPTION
Fixes #353.

Turns out `updateJob` and the edit dialog never ran manifests through `validateJobManifest` at all — only the create path did. So a Job could get created with volume checks enforced, then edited into an invalid state (e.g. a task volume with `mountPath` but no `volumeClaim`/`volumeClaimName`) with no pushback from the UI or the API layer.

This brings edit in line with create:
- `job-edit-dialog.tsx`'s `parseYamlToManifest` now checks `spec.tasks` is a non-empty array and runs the parsed manifest through `validateJobManifest`, same as `create-job-dialog.tsx` already does.
- `updateJob` in `jobs.ts` now validates the merged `updatedJob` before calling `replaceNamespacedCustomObject`, same as `createJob` does before `createNamespacedCustomObject`.

Both sides reuse the existing `validateJobManifest` helpers, so this is a pretty small diff — no new validation logic, just wiring the existing checks into the path that was missing them.

**Test plan:**
- [x] `tsc --noEmit` passes for both touched files
- [ ] Manually edit a Job's YAML to add a task volume with `mountPath` but no `volumeClaim`, confirm it's now rejected with the same message create would give