### PR TITLE
fix: clear stale auto-close timer in edit dialogs

### DIFF
--- a/apps/web/src/components/(dashboard)/jobs/job-edit-dialog.tsx
+++ b/apps/web/src/components/(dashboard)/jobs/job-edit-dialog.tsx
@@ -38,12 +38,27 @@ export function JobEditDialog({ open, setOpen, handleRefresh, jobName, jobNamesp
         message: string
     }>({ type: null, message: "" })
 
+    const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
     React.useEffect(() => {
         if (open) {
             setYaml(initialYaml)
             setStatus({ type: null, message: "" })
+
+            if (closeTimeoutRef.current) {
+                clearTimeout(closeTimeoutRef.current)
+                closeTimeoutRef.current = null
+            }
         }
     }, [open, initialYaml])
+
+    React.useEffect(() => {
+        return () => {
+            if (closeTimeoutRef.current) {
+                clearTimeout(closeTimeoutRef.current)
+            }
+        }
+    }, [])
 
     const { mutateAsync: updateJob, isPending: isUpdating } = trpc.jobsRouter.updateJob.useMutation({
         onSuccess: () => {
@@ -52,7 +67,8 @@ export function JobEditDialog({ open, setOpen, handleRefresh, jobName, jobNamesp
                 message: t("edit.success"),
             })
 
-            setTimeout(() => {
+            closeTimeoutRef.current = setTimeout(() => {
+                closeTimeoutRef.current = null
                 setOpen(false)
                 handleRefresh()
             }, 1000)

--- a/apps/web/src/components/(dashboard)/pods/pod-edit-dialog.tsx
+++ b/apps/web/src/components/(dashboard)/pods/pod-edit-dialog.tsx
@@ -38,12 +38,27 @@ export function PodEditDialog({ open, setOpen, handleRefresh, podName, podNamesp
         message: string
     }>({ type: null, message: "" })
 
+    const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
     React.useEffect(() => {
         if (open) {
             setYaml(initialYaml)
             setStatus({ type: null, message: "" })
+
+            if (closeTimeoutRef.current) {
+                clearTimeout(closeTimeoutRef.current)
+                closeTimeoutRef.current = null
+            }
         }
     }, [open, initialYaml])
+
+    React.useEffect(() => {
+        return () => {
+            if (closeTimeoutRef.current) {
+                clearTimeout(closeTimeoutRef.current)
+            }
+        }
+    }, [])
 
     const { mutateAsync: updatePod, isPending: isUpdating } = trpc.podRouter.updatePod.useMutation({
         onSuccess: () => {
@@ -52,7 +67,8 @@ export function PodEditDialog({ open, setOpen, handleRefresh, podName, podNamesp
                 message: t("edit.success"),
             })
 
-            setTimeout(() => {
+            closeTimeoutRef.current = setTimeout(() => {
+                closeTimeoutRef.current = null
                 setOpen(false)
                 handleRefresh()
             }, 1000)

--- a/apps/web/src/components/(dashboard)/queues/queue-edit-dialog.tsx
+++ b/apps/web/src/components/(dashboard)/queues/queue-edit-dialog.tsx
@@ -74,6 +74,8 @@ export function QueueEditDialog({
     return parsed
   }, [])
 
+  const closeTimeoutRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
   React.useEffect(() => {
     if (open && initialYaml) {
       setYaml(initialYaml)
@@ -84,13 +86,27 @@ export function QueueEditDialog({
       } catch {
         setMode("yaml")
       }
+
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current)
+        closeTimeoutRef.current = null
+      }
     }
   }, [open, initialYaml, loadFromYaml])
+
+  React.useEffect(() => {
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current)
+      }
+    }
+  }, [])
 
   const { mutateAsync: updateQueue, isPending: isUpdating } = trpc.queueRouter.updateQueue.useMutation({
     onSuccess: () => {
       setStatus({ type: "success", message: t("edit.success") })
-      setTimeout(() => {
+      closeTimeoutRef.current = setTimeout(() => {
+        closeTimeoutRef.current = null
         setOpen(false)
         handleRefresh()
       }, 1000)


### PR DESCRIPTION
Fixes #364.

`PodEditDialog`, `JobEditDialog`, and `QueueEditDialog` all schedule a `setTimeout` on a successful update to close the dialog and trigger a refresh, but never store or clear the id. These dialogs stay mounted for the life of the page too — the parent components only ever set the target resource (`podToEdit`/etc.), never null it back out — so it's the same component instance across edit sessions, closures and all.

Put those together and you get a real race: update pod A, the 1s auto-close timer starts, close the dialog manually within that second and reopen it (same pod or a different one), start editing again. The stale timer fires mid-edit, force-closes whatever's open and calls `handleRefresh()`, silently dropping the new unsaved edit.

Fix: keep the timeout id in a `useRef`, clear it whenever the dialog reopens for a new session and on unmount, before scheduling a fresh one. Same small fix applied identically to all three dialogs.

**Test plan:**
- [x] `tsc --noEmit` passes for all three touched files
- [ ] Manually reproduce: update a resource, close the dialog within 1s, reopen and start a new edit, confirm the old timer no longer force-closes it