### PR TITLE
fix: validate Pod edits the same way Pod creates are validated

### DIFF
--- a/apps/web/src/components/(dashboard)/pods/pod-edit-dialog.tsx
+++ b/apps/web/src/components/(dashboard)/pods/pod-edit-dialog.tsx
@@ -105,6 +105,31 @@ export function PodEditDialog({ open, setOpen, handleRefresh, podName, podNamesp
                 throw new Error('Invalid spec: must be an object')
             }
 
+            // Validate containers
+            if (!parsed.spec.containers || !Array.isArray(parsed.spec.containers)) {
+                throw new Error('Pod spec must include containers array')
+            }
+
+            if (parsed.spec.containers.length === 0) {
+                throw new Error('Pod spec must include at least one container')
+            }
+
+            // Validate each container
+            for (let i = 0; i < parsed.spec.containers.length; i++) {
+                const container = parsed.spec.containers[i]
+                if (!container || typeof container !== 'object') {
+                    throw new Error(`Container at index ${i} must be an object`)
+                }
+
+                if (!container.name || typeof container.name !== 'string') {
+                    throw new Error(`Container at index ${i} must have a name`)
+                }
+
+                if (!container.image || typeof container.image !== 'string') {
+                    throw new Error(`Container at index ${i} must have an image`)
+                }
+            }
+
             return parsed
         } catch (error) {
             if (error instanceof YAMLException) {


### PR DESCRIPTION
Fixes #379.

Same shape of bug as #353 (Job side): `pod-edit-dialog.tsx`'s `parseYamlToManifest` stopped right after the generic "spec must be an object" check, so editing a pod's YAML to drop the `containers:` block or leave a container without an `image` sailed straight through to the k8s apiserver instead of getting caught client-side the way create already catches it.

This ports the containers-array/container-shape checks straight from `pod-create-dialog.tsx`'s `parseYamlToManifest` — same non-empty-array check, same per-container `name`/`image` checks, same error messages. No new validation logic, just closing the gap between the two dialogs.

Worth noting: unlike the Job case, there's no shared `validate*Manifest` helper reused on the backend here — `createPod`/`updatePod` in `pods.ts` don't run any manifest validation at all, so this is a client-side-only fix, same scope as the create dialog's existing checks.

**Test plan:**
- [x] `tsc --noEmit` passes for the touched file
- [ ] Manually edit a pod's YAML to remove `containers:` or drop a container's `image`, confirm Update is now rejected client-side with the same message create would give