### PR TITLE
fix: parse all Kubernetes memory suffixes in queue resources chart

### DIFF
--- a/apps/web/src/components/(dashboard)/bar-chart.tsx
+++ b/apps/web/src/components/(dashboard)/bar-chart.tsx
@@ -4,10 +4,13 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from "@/components/ui/chart"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Skeleton } from "@/components/ui/skeleton"
+import { parseMemoryToBytes } from "@/lib/queue-validation"
 import { Loader2Icon } from "lucide-react"
 import { useTranslations } from "next-intl"
 import { useEffect, useMemo, useState } from "react"
 import { Bar, BarChart, CartesianGrid, XAxis, YAxis } from "recharts"
+
+const BYTES_PER_GI = 1024 ** 3
 
 interface QueueMetrics {
   name: string
@@ -51,23 +54,22 @@ const QueueResourcesBarChart = ({ data = [], isLoading = false }: QueueResources
   const t = useTranslations("dashboard")
   const [selectedResource, setSelectedResource] = useState("")
 
-  const parseResourceValue = (value: string | number | undefined): number => {
+  const parseResourceValue = (value: string | number | undefined, kind: "cpu" | "memory" | "count"): number => {
     if (value === undefined || value === null || value === "") return 0
     const str = String(value).trim()
     if (str === "0") return 0
 
-    if (str.endsWith("m")) {
-      return Number.parseFloat(str.slice(0, -1)) / 1000
+    if (kind === "cpu") {
+      if (str.endsWith("m")) {
+        return Number.parseFloat(str.slice(0, -1)) / 1000
+      }
+      const n = Number.parseFloat(str)
+      return Number.isFinite(n) ? n : 0
     }
 
-    if (/Gi$/i.test(str)) {
-      return Number.parseFloat(str)
-    }
-    if (/Mi$/i.test(str)) {
-      return Number.parseFloat(str) / 1024
-    }
-    if (/Ki$/i.test(str)) {
-      return Number.parseFloat(str) / (1024 * 1024)
+    if (kind === "memory") {
+      const bytes = parseMemoryToBytes(str)
+      return bytes === null ? 0 : bytes / BYTES_PER_GI
     }
 
     const n = Number.parseFloat(str)
@@ -79,16 +81,16 @@ const QueueResourcesBarChart = ({ data = [], isLoading = false }: QueueResources
       metadata: { name: queue.name },
       status: {
         allocated: {
-          cpu: parseResourceValue(queue.cpu),
-          memory: parseResourceValue(queue.memory),
-          pods: parseResourceValue(queue.pods),
+          cpu: parseResourceValue(queue.cpu, "cpu"),
+          memory: parseResourceValue(queue.memory, "memory"),
+          pods: parseResourceValue(queue.pods, "count"),
         },
       },
       spec: {
         capability: {
-          cpu: parseResourceValue(queue.cpuCapability),
-          memory: parseResourceValue(queue.memoryCapability),
-          pods: parseResourceValue(queue.podsCapability),
+          cpu: parseResourceValue(queue.cpuCapability, "cpu"),
+          memory: parseResourceValue(queue.memoryCapability, "memory"),
+          pods: parseResourceValue(queue.podsCapability, "count"),
         },
       },
     }))


### PR DESCRIPTION
Fixes #385.

`parseResourceValue` in `bar-chart.tsx` only matched `Ki`/`Mi`/`Gi` suffixes when normalizing queue memory values to Gi for the chart. Anything else — `Ti`, `Pi`, `Ei`, decimal SI suffixes (`K`/`M`/`G`/`T`/`P`/`E`), or a bare byte integer with no suffix — fell through to the final branch and got `parseFloat`'d as if it were already in Gi. A queue with `4Ti` of memory capacity rendered as `4` on an axis labeled Gi (1024x off), and a raw byte count like `8589934592` (8Gi) rendered as `8589934592`, blowing out the whole chart scale.

There's already a `parseMemoryToBytes` helper in `queue-validation.ts` that handles the full Kubernetes suffix set correctly (it's used for the guarantee/deserved/capability comparisons in the queue forms). Rather than duplicate that logic, `parseResourceValue` now delegates to it for memory values and divides by `1024**3` to get back to Gi.

Since the function was shared across cpu/memory/pod-count parsing with no way to tell them apart, I gave it a `kind` parameter (`"cpu" | "memory" | "count"`) so cpu's `m`-suffix handling and the plain pod-count parsing stay exactly as they were — only the memory path changed.

**Test plan:**
- [x] `tsc --noEmit` and `eslint` pass for the touched file
- [x] Verified the parsing logic against known conversions: `4Ti` → 4096 Gi, `8589934592` bytes → 8 Gi, `500M` → ~0.4657 Gi, `2G` → ~1.8626 Gi, `4Gi` → 4 Gi, `512Mi` → 0.5 Gi
- [ ] Manually confirm in the running dashboard against a queue with a Ti-scale or byte-scale memory value